### PR TITLE
chore(docs): add spark-ui and storybook testing to frontend

### DIFF
--- a/docs/Onboarding/6-FrontendDevelopment.md
+++ b/docs/Onboarding/6-FrontendDevelopment.md
@@ -45,43 +45,20 @@ apps/nexus-web/src/
 -   **`providers/`**: Holds React context providers that wrap the entire application.
 -   **`hooks/`**: Contains custom React hooks for shared, reusable logic.
 
-## Internal UI Library (Spark-UI)
+### Internal UI Library (SparkUI)
 
-We use **Spark-UI**, our internal component library and design system, to ensure
-visual consistency, accessibility, and reuse across all frontend applications.
+We use **SparkUI**, our internal component library and design system, for all shared UI across frontend applications.
 
-Spark-UI lives outside of the application code and is shared via the monorepo:
+Spark-UI provides reusable, brand-level components and defines visual behavior, accessibility, and theming. Application code should **compose SparkUI components**, not reimplement them. Feature-specific UI remains inside the application (`components/features`).
 
-```
-packages/
-└── spark-ui/
-```
+All Spark-UI components are **documented and visually tested in Storybook**, which serves as the source of truth for component usage, appearance, and supported variants.
 
-### Key principles
+Before building new UI components in the application, always consult:
 
-- Spark-UI contains **reusable, brand-level UI components**
-- Application code should **compose**, not reimplement, Spark-UI components
-- Feature-specific UI stays inside the app (`components/features`)
-- Styling and theming are driven by shared design tokens
+- **SparkUI source & documentation:** [SparkUI/README.md](../SparkUI/README.md)
+- **Component usage & visual reference:** Storybook (`apps/storybook`)
 
-### Documentation & Visual Testing
-
-Spark-UI components are documented and visually tested using **Storybook**.
-
-- **Source code:** `packages/spark-ui`
-- **Component documentation & usage examples:** Storybook (`apps/storybook`)
-- **Visual regression & interaction testing:** Storybook serves as the primary visual testing surface
-
-Storybook is the **source of truth** for Spark-UI component behavior, appearance, and supported variants.
-
-Before building new UI components in the application, always check Spark-UI and its Storybook documentation first.
-
-### Component Ownership
-
-We distinguish between shared UI components and application-specific components.
-
-- **Shared, reusable UI** lives in **Spark-UI** (`packages/spark-ui`)
-- **Feature-specific UI** lives inside the application (`components/features`)
+For detailed ownership rules and contribution guidelines, see: [SparkUI Documentation](../SparkUI/README.md)
 
 ## Type-Safe API Client 
 

--- a/docs/SparkUI/01-introduction.md
+++ b/docs/SparkUI/01-introduction.md
@@ -1,0 +1,19 @@
+**[Back to Spark UI Docs](./README.md)** | **[Next: Ownership & Boundaries ➡️](./02-ownership-and-boundaries.md)**
+
+---
+
+# Introduction
+
+Spark-UI is the shared UI foundation for all frontend applications.
+
+Its goals are to:
+- Ensure visual and interaction consistency
+- Centralize accessibility and UI behavior
+- Reduce duplication and ad-hoc styling
+- Provide a stable base for feature development
+
+Applications **compose** Spark-UI components — they do not reimplement them.
+
+---
+
+**[Back to Spark UI Docs](./README.md)** | **[Next: Ownership & Boundaries ➡️](./02-ownership-and-boundaries.md)**

--- a/docs/SparkUI/02-ownership-and-boundaries.md
+++ b/docs/SparkUI/02-ownership-and-boundaries.md
@@ -1,0 +1,43 @@
+**[⬅️ Previous: Introduction](./01-introduction.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Using Spark UI ➡️](./03-using-spark-ui.md)**
+
+---
+
+# Ownership & Boundaries
+
+Clear ownership boundaries keep UI scalable and maintainable.
+
+## What belongs in Spark-UI
+
+Spark-UI contains:
+- Reusable, brand-level UI components
+- UI primitives and patterns
+- Components independent of business logic
+
+Examples:
+- Button
+- Input
+- Modal
+- Card
+- Tabs
+
+## What belongs in applications
+
+Application code contains:
+- Feature-specific components
+- Route-aware or domain-aware UI
+- Compositions of Spark-UI components
+
+Examples:
+- UserProfileCard
+- EventDetailsPanel
+- CheckoutSummary
+
+## Rule of Thumb
+
+If a component is reused across features or applications, it likely belongs in Spark-UI.
+
+When in doubt, start in the app and promote once reuse is clear.
+
+---
+
+**[⬅️ Previous: Introduction](./01-introduction.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Using Spark UI ➡️](./03-using-spark-ui.md)**

--- a/docs/SparkUI/03-using-spark-ui.md
+++ b/docs/SparkUI/03-using-spark-ui.md
@@ -1,0 +1,23 @@
+**[⬅️ Previous: Ownership & Boundaries](./02-ownership-and-boundaries.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Storybook & Visual Testing ➡️](./04-storybook-and-visual-testing.md)**
+
+---
+
+# Using Spark-UI
+
+Applications consume Spark-UI via workspace imports.
+
+```tsx
+import { Button, Card } from "@packages/spark-ui";
+```
+# Usage guidelines
+
+- Prefer Spark-UI components over raw HTML
+- Do not override Spark-UI styles ad-hoc
+- Compose Spark-UI components inside feature components
+
+Spark-UI defines **how UI looks and behaves.**
+Applications define **what the UI does.**
+
+---
+
+**[⬅️ Previous: Ownership & Boundaries](./02-ownership-and-boundaries.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Storybook & Visual Testing ➡️](./04-storybook-and-visual-testing.md)**

--- a/docs/SparkUI/04-storybook-and-visual-testing.md
+++ b/docs/SparkUI/04-storybook-and-visual-testing.md
@@ -1,0 +1,35 @@
+**[⬅️ Previous: Using Spark UI](./03-using-spark-ui.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Styling & Theming ➡️](./05-styling-and-theming.md)**
+
+---
+
+# Storybook & Visual Testing
+
+Storybook is the source of truth for Spark-UI components.
+
+## Storybook responsibilities
+
+Storybook documents:
+- Component APIs
+- Supported variants
+- Visual states
+- Interaction behavior
+- Accessibility expectations
+
+## Location
+
+```tsx
+apps/
+└── storybook/
+```
+
+## Visual testing
+
+Storybook also serves as the primary visual regression testing surface.
+
+If a change breaks visuals in Storybook, it is considered a breaking UI change.
+
+Every Spark-UI component **must** have a Storybook entry.
+
+---
+
+**[⬅️ Previous: Using Spark UI](./03-using-spark-ui.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Styling & Theming ➡️](./05-styling-and-theming.md)**

--- a/docs/SparkUI/05-styling-and-theming.md
+++ b/docs/SparkUI/05-styling-and-theming.md
@@ -1,0 +1,19 @@
+**[⬅️ Previous: Storybook & Visual Testing](./04-storybook-and-visual-testing.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Adding & Changing Components ➡️](./06-adding-and-changing-components.md)**
+
+---
+
+# Styling & Theming
+
+Spark-UI styling is driven by shared design tokens.
+
+## Principles
+
+- Tokens define colors, spacing, typography, and radii
+- Applications should not redefine core visual tokens
+- Global theming decisions are owned by Spark-UI
+
+Any new token or theme change should be discussed before implementation.
+
+---
+
+**[⬅️ Previous: Storybook & Visual Testing](./04-storybook-and-visual-testing.md)** | **[Back to Spark UI Docs](./README.md)** | **[Next: Adding & Changing Components ➡️](./06-adding-and-changing-components.md)**

--- a/docs/SparkUI/06-adding-and-changing-components.md
+++ b/docs/SparkUI/06-adding-and-changing-components.md
@@ -1,0 +1,27 @@
+**[⬅️ Previous: Styling & Theming](./05-styling-and-theming.md)** | **[Back to Spark UI Docs](./README.md)**
+
+---
+
+# Adding & Changing Components
+
+Changes to Spark-UI affect all consuming applications.
+
+## Adding a new component
+
+1. Confirm the component belongs in Spark-UI
+2. Implement the component
+3. Add full Storybook documentation
+4. Ensure accessibility considerations are met
+5. Export from the package entry point
+
+Components without Storybook documentation are considered incomplete.
+
+## Making changes
+
+- Minor visual changes should be communicated
+- Breaking changes require coordination
+- Storybook must be updated alongside code changes
+
+---
+
+**[⬅️ Previous: Styling & Theming](./05-styling-and-theming.md)** | **[Back to Spark UI Docs](./README.md)**

--- a/docs/SparkUI/README.md
+++ b/docs/SparkUI/README.md
@@ -1,0 +1,12 @@
+# Spark-UI Documentation
+
+This documentation describes how Spark-UI works, what belongs in it, and how it is used across applications.
+
+## Sections
+
+- [Introduction](./01-introduction.md)
+- [Ownership & Boundaries](./02-ownership-and-boundaries.md)
+- [Using Spark-UI](./03-using-spark-ui.md)
+- [Storybook & Visual Testing](./04-storybook-and-visual-testing.md)
+- [Styling & Theming](./05-styling-and-theming.md)
+- [Adding & Changing Components](./06-adding-and-changing-components.md)


### PR DESCRIPTION
This pull request updates the frontend onboarding documentation to clarify the structure and usage of UI components. The main focus is to document the adoption of the internal Spark-UI library, clarify the distinction between shared and feature-specific components, and provide guidance on component ownership and documentation.

Key documentation improvements:

**Component organization and Spark-UI adoption:**
- Updated the `components/` directory structure to remove references to the previous `ui/` folder and clarify that application-specific UI is composed from Spark-UI components.
- Added a new section describing Spark-UI as the internal UI library, including its location in the monorepo, its role as the source of reusable, brand-level UI, and the principle that application code should compose (not reimplement) Spark-UI components.

**Documentation and visual testing practices:**
- Documented the use of Storybook for Spark-UI, emphasizing its role for component documentation, usage examples, and visual regression/interaction testing.

**Component ownership guidelines:**
- Clarified the distinction between shared UI (in `packages/spark-ui`) and feature-specific UI (in `components/features`), and provided guidance on where new components should be implemented.

**Related Issue**
- Closes #33 