### PR TITLE
docs: update monorepo structure in Project Architecture document

### DIFF
--- a/docs/Onboarding/1-ProjectArchitecture.md
+++ b/docs/Onboarding/1-ProjectArchitecture.md
@@ -22,20 +22,23 @@ The project is built with the following technologies:
 The repository is organized as a monorepo with the following structure:
 
 ```
-gdgnexussecondclone/
+gdg-pup-platform/ 
 ├── apps/
 │   ├── nexus-api/              # Express.js Backend API
 │   ├── nexus-web/              # Next.js Frontend
-│   └── identity-api/           # Authentication Service
+│   ├── identity-api/           # Authentication Service
+│   └── storybook/              # Storybook app for UI development
 │
 ├── packages/
 │   ├── typed-rest/             # Type-safe API client/server helpers
 │   ├── nexus-api-contracts/    # API contract definitions & schemas
-│   └── identity-api-contracts/ # Identity service API contracts
+│   ├── identity-api-contracts/ # Identity service API contracts
+│   └── spark-ui/               # Internal component library (Spark UI)
 │
 ├── configs/
 │   ├── eslint-config/          # Shared ESLint configuration
-│   └── typescript-config/      # Shared TypeScript configuration
+│   ├── typescript-config/      # Shared TypeScript configuration
+│   └── tailwind-config/        # Shared Tailwind CSS configuration
 │
 ├── .gitignore
 ├── package.json                # Root workspace configuration


### PR DESCRIPTION
This pull request updates the project architecture documentation to reflect recent changes in the monorepo structure. The main improvements include clarifying directory names and adding new apps and packages for UI development and shared configuration.

**Documentation updates:**

* Renamed the root directory from `gdgnexussecondclone` to `gdg-pup-platform` for clarity and accuracy.
* Added the `storybook` app under `apps/` to document the inclusion of a Storybook app for UI development.
* Added the `spark-ui` package under `packages/` to indicate the presence of an internal component library.
* Added the `tailwind-config` directory under `configs/` for shared Tailwind CSS configuration.