### PR TITLE
fix(typed-rest): merge default props and passed props to keep default…

### DIFF
--- a/apps/nexus-api/src/loaders/docs.loader.ts
+++ b/apps/nexus-api/src/loaders/docs.loader.ts
@@ -23,6 +23,7 @@ export const docsLoader = (app: Express) => {
     servers: [{ url: "http://localhost:8000", description: "Local Dev" }],
     generateExample: false,
   });
+  const swaggerSpec = swaggerJsdoc(options);
 
   /**
    * EXPOSE THE OPENAPI DOCUMENT
@@ -91,7 +92,6 @@ export const docsLoader = (app: Express) => {
   /**
    * LOAD SWAGGER UI DOCUMENTATION
    */
-  const swaggerSpec = swaggerJsdoc(options);
   const assetOptions = {
     customCssUrl:
       "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui.min.css",

--- a/packages/typed-rest/src/application/generation/generateOpenApiOptions.ts
+++ b/packages/typed-rest/src/application/generation/generateOpenApiOptions.ts
@@ -23,6 +23,7 @@ export const generateOpenApiOptions = ({
   generateExample?: boolean;
   openapiendpoints?: any[];
 }) => {
+
   const registry = new OpenAPIRegistry();
 
   const extractPathParams = (path: string): string[] => {

--- a/packages/typed-rest/src/application/generation/writeOpenApiGenerator.ts
+++ b/packages/typed-rest/src/application/generation/writeOpenApiGenerator.ts
@@ -87,6 +87,22 @@ export const generateOpenApiSpec = (
     openapiendpoints: openapiendpoints,
   },
 ) => {
-  return generateOpenApiOptions(props);
+  const defaultProps = {
+    info: {
+      title: "API Documentation",
+      version: "1.0.0",
+      description: "Generated Documentation",
+    },
+    servers: [
+      { url: "http://localhost:8000", description: "Development server" },
+    ],
+    security: [{ bearerAuth: [] }],
+    generateExample: true,
+    openapiendpoints: openapiendpoints,
+  }; 
+  return generateOpenApiOptions({
+    ...defaultProps,
+    ...props,
+  });
 };
 `;


### PR DESCRIPTION
… openapiendpoints value

## related issue
closes #122 

## summary 
passing props without openapiendpoints property will override default openapiendpoint to null

## strategies
merge default values and passed props (prioritized)
