### PR TITLE
chore(storybook): add --ci flag to dev and storybook scripts for improved CI compatibility

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "storybook dev -p 6006",
+    "dev": "storybook dev -p 6006 --ci",
     "build": "storybook build",
     "start": "next start",
     "lint": "eslint",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --ci",
+    "dev:open": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
This pull request makes a minor update to the `apps/storybook/package.json` scripts. The main change is adding the `--ci` flag to the Storybook development commands to ensure they run in continuous integration mode, and introducing a new script to open Storybook without the `--ci` flag.

- Storybook script improvements:
  * Added the `--ci` flag to the `dev` and `storybook` scripts to enable CI-friendly behavior.
  * Introduced a new `dev:open` script to run Storybook locally without the `--ci` flag.