### PR TITLE
chore: update text variant for consistency in Footer and Navbar

### DIFF
--- a/apps/nexus-web/src/components/shared/Footer.tsx
+++ b/apps/nexus-web/src/components/shared/Footer.tsx
@@ -114,7 +114,7 @@ export const Footer: React.FC = () => {
                 height={40}
                 className="w-10 h-10 group-hover:scale-110 transition-transform duration-300"
               />
-              <Text variant="heading-4" weight="bold" className="text-white">
+              <Text variant="heading-6" weight="bold" className="text-white">
                 GDG PUP NEXUS
               </Text>
             </Link>

--- a/apps/nexus-web/src/components/shared/Navbar.tsx
+++ b/apps/nexus-web/src/components/shared/Navbar.tsx
@@ -131,7 +131,7 @@ export const Navbar: React.FC<NavbarProps> = ({
                     height={40}
                     className="w-8 h-8 lg:w-10 lg:h-10"
                   />
-                  <Text variant="heading-4" weight="bold" className="text-white tracking-tight">
+                  <Text variant="heading-6" weight="bold" className="text-white tracking-tight">
                     GDG PUP NEXUS
                   </Text>
                 </Inline>


### PR DESCRIPTION
This pull request makes a minor adjustment to the visual hierarchy of the GDG PUP NEXUS branding in the UI. The heading variant for the text label is changed from `heading-4` to `heading-6` in both the `Footer` and `Navbar` components, resulting in a smaller and less prominent display.

* UI consistency and visual hierarchy:
  * Changed the `Text` component variant from `heading-4` to `heading-6` for the GDG PUP NEXUS label in both `Footer.tsx` and `Navbar.tsx` to reduce its prominence and improve overall visual hierarchy. 