### PR TITLE
chore(nexus-web): minor adjustment to footer

### DIFF
--- a/apps/nexus-web/src/components/shared/Footer.tsx
+++ b/apps/nexus-web/src/components/shared/Footer.tsx
@@ -221,7 +221,7 @@ export const Footer: React.FC = () => {
         </Box>
 
         {/* White divider line */}
-        <Box className="border-t border-white/20 mb-8"> </Box>
+        <div className="border-t border-white mb-8"> </div>
 
         {/* Bottom Section: Copyright & Social */}
         <Inline


### PR DESCRIPTION
This pull request makes a minor change to the `Footer` component. The divider line between sections has been updated to use a solid white border instead of a semi-transparent one.

* Changed the divider line in the `Footer` component from a semi-transparent white border to a solid white border by replacing the `Box` element with a `div` and updating the border class. (`apps/nexus-web/src/components/shared/Footer.tsx`)