### PR TITLE
feat(spark-ui): enhance shine border animation with hover effect

### DIFF
--- a/packages/spark-ui/src/components/shine-border/ShineBorder.tsx
+++ b/packages/spark-ui/src/components/shine-border/ShineBorder.tsx
@@ -48,12 +48,14 @@ export function ShineBorder({
   shineColor = GOOGLE_SHINE_COLORS as unknown as string[],
   className,
   style,
+  ref,
   ...props
-}: ShineBorderProps) {
+}: ShineBorderProps & { ref?: React.Ref<HTMLDivElement> }) {
   const colors = Array.isArray(shineColor) ? shineColor.join(",") : shineColor;
 
   return (
     <div
+      ref={ref}
       style={
         {
           "--border-width": `${borderWidth}px`,

--- a/packages/spark-ui/src/components/team-card/TeamCard.tokens.ts
+++ b/packages/spark-ui/src/components/team-card/TeamCard.tokens.ts
@@ -25,7 +25,15 @@ export const TEAM_CARD_BORDER_WIDTH = 4.5;
 export const TEAM_CARD_RADIUS = 28;
 
 /** Animation duration for ShineBorder sweep (seconds). */
-export const TEAM_CARD_SHINE_DURATION = 10;
+export const TEAM_CARD_SHINE_DURATION = 14;
+
+/**
+ * Animation duration for ShineBorder sweep while the card is hovered (seconds).
+ * Set lower than TEAM_CARD_SHINE_DURATION for a fast, emphatic spin on hover.
+ * 2  → fast and punchy ← default
+ * 4  → moderate
+ */
+export const TEAM_CARD_SHINE_DURATION_HOVER = 3;
 
 /** Maximum 3D tilt rotation capped at this value (degrees). */
 export const TEAM_CARD_TILT_MAX = 6;

--- a/packages/spark-ui/src/components/team-card/TeamCard.tsx
+++ b/packages/spark-ui/src/components/team-card/TeamCard.tsx
@@ -14,6 +14,7 @@ import {
 import {
   TEAM_CARD_SHINE_COLORS,
   TEAM_CARD_SHINE_DURATION,
+  TEAM_CARD_SHINE_DURATION_HOVER,
   TEAM_CARD_BORDER_WIDTH,
   TEAM_CARD_TILT_MAX,
   TEAM_CARD_PERSPECTIVE,
@@ -137,6 +138,8 @@ export const TeamCard = React.forwardRef<HTMLDivElement, TeamCardProps>(
     const cardRef = React.useRef<HTMLDivElement>(null);
     // Ref for direct DOM mutation of the mascot tilt — avoids React re-renders on mousemove
     const mascotRef = React.useRef<HTMLImageElement>(null);
+    // Ref to ShineBorder element for direct --duration manipulation on hover
+    const shineRef = React.useRef<HTMLDivElement>(null);
 
     // Merge forwarded ref + internal ref
     const setRef = React.useCallback(
@@ -178,6 +181,11 @@ export const TeamCard = React.forwardRef<HTMLDivElement, TeamCardProps>(
         // Apply directly to DOM to avoid React re-render on every mousemove
         Object.assign(cardRef.current.style, nextStyle);
 
+        // Speed up the shine border on hover for emphasis
+        if (shineRef.current) {
+          shineRef.current.style.setProperty("--duration", `${TEAM_CARD_SHINE_DURATION_HOVER}s`);
+        }
+
         // Tilt the mascot slightly based on horizontal cursor position
         if (mascotRef.current) {
           const mascotRotate = nx * 18; // max ±18deg
@@ -201,6 +209,11 @@ export const TeamCard = React.forwardRef<HTMLDivElement, TeamCardProps>(
 
         tiltStyle.current = resetStyle;
         Object.assign(cardRef.current.style, resetStyle);
+
+        // Slow the shine border back to idle speed
+        if (shineRef.current) {
+          shineRef.current.style.setProperty("--duration", `${shineDuration}s`);
+        }
 
         // Reset mascot back to neutral
         if (mascotRef.current) {
@@ -226,8 +239,9 @@ export const TeamCard = React.forwardRef<HTMLDivElement, TeamCardProps>(
         onMouseLeave={handleMouseLeave}
         {...props}
       >
-        {/* Animated ShineBorder ring */}
+        {/* Animated ShineBorder ring — ref lets us update --duration directly on hover */}
         <ShineBorder
+          ref={shineRef}
           borderWidth={TEAM_CARD_BORDER_WIDTH}
           duration={shineDuration}
           shineColor={shineColor}


### PR DESCRIPTION
## Summary
This pull request enhances the `TeamCard` component's shine animation by allowing the shine border to animate faster on hover for a more dynamic visual effect. It does this by introducing a hover-specific duration for the shine animation and updating the component logic to adjust the animation speed in response to mouse events. The changes also improve ref handling for direct DOM manipulation.

**Shine animation improvements:**

* Added a new constant `TEAM_CARD_SHINE_DURATION_HOVER` to control the shine animation speed when the card is hovered, and increased the default shine duration for idle state.
* Modified the `TeamCard` component to use a `shineRef` for the `ShineBorder`, allowing direct updates to the CSS `--duration` property on hover and mouse leave events, enabling smooth speed transitions. 
* Updated the `ShineBorder` component to accept and forward a `ref`, making it possible to manipulate its DOM node directly from the parent component.

**Token and import updates:**

* Imported the new `TEAM_CARD_SHINE_DURATION_HOVER` constant into `TeamCard.tsx` for use in the component logic.