### PR TITLE
feat(contracts): removed gen-types commands

### DIFF
--- a/packages/identity-api-contracts/package.json
+++ b/packages/identity-api-contracts/package.json
@@ -6,8 +6,7 @@
   "imports": {
     "#*": "./dist/*"
   },
-  "scripts": { 
-    "gen-contract": "typed-rest",
+  "scripts": {  
     "dev": "typed-rest dev",
     "build": "typed-rest build"
   },

--- a/packages/nexus-api-contracts/package.json
+++ b/packages/nexus-api-contracts/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": { 
     "dev": "typed-rest dev",
-    "build": "typed-rest build",
-    "gen-types:rebuild": "pnpm run gen-types && pnpm run build"
+    "build": "typed-rest build"  
   },
   "dependencies": {
     "@configs/typescript-config": "workspace:*",


### PR DESCRIPTION
## related issues 
closes #352 


## summary 
- removed the gentype commands from the package json of both api contract packages