### PR TITLE
docs(nexus-web): create docs on how to use the new public assets

### DIFF
--- a/docs/Onboarding/6-FrontendDevelopment.md
+++ b/docs/Onboarding/6-FrontendDevelopment.md
@@ -1,4 +1,4 @@
-**[⬅️ Previous: Error Handling](./5-ErrorHandling.md)** | **[Back to Onboarding](./README.md)** | **[Next: Development Workflow ➡️](./7-DevelopmentWorkflow.md)**
+**[⬅️ Previous: Error Handling](./5-ErrorHandling.md)** | **[Back to Onboarding](./README.md)** | **[Next: Public Assets ➡️](./6.1-PublicAssets.md)**
 
 ---
 
@@ -352,7 +352,3 @@ export default function UserPage({ params }: { params: { userId: string } }) {
   return <UserProfileCard profile={profile} />;
 }
 ```
-
----
-
-**[⬅️ Previous: Error Handling](./5-ErrorHandling.md)** | **[Back to Onboarding](./README.md)** | **[Next: Development Workflow ➡️](./7-DevelopmentWorkflow.md)**

--- a/docs/Onboarding/6.1-PublicAssets.md
+++ b/docs/Onboarding/6.1-PublicAssets.md
@@ -214,10 +214,3 @@ Always clear the Next.js cache before restarting — otherwise stale 404s will p
 ```bash
 rm -rf .next && pnpm dev
 ```
-
-See [`bug-assets-not-rendering.md`](../../apps/nexus-web/bug-assets-not-rendering.md) for full details on this gotcha.
-
----
-
-**[⬅️ Previous: Frontend Development](./6-FrontendDevelopment.md)** | **[Back to Onboarding](./README.md)** | **[Next: Development Workflow ➡️](./7-DevelopmentWorkflow.md)**
-

--- a/docs/Onboarding/6.1-PublicAssets.md
+++ b/docs/Onboarding/6.1-PublicAssets.md
@@ -1,0 +1,223 @@
+**[⬅️ Previous: Frontend Development](./6-FrontendDevelopment.md)** | **[Back to Onboarding](./README.md)** | **[Next: Development Workflow ➡️](./7-DevelopmentWorkflow.md)**
+
+---
+
+# Public Asset System — Developer Guide
+
+This document covers how to use, add, and maintain assets in `nexus-web`.
+
+---
+
+## Core Principle
+
+**Never hardcode image paths in components.** All asset paths live in one place:
+
+```
+src/lib/constants/assets.ts
+```
+
+Import the `ASSETS` object and use its typed constants instead of string literals.
+
+---
+
+## Directory Structure
+
+```
+public/
+├── branding/      GDG logos (SVG + WebP)
+├── home/          Hero parallax layers, mascot illustration, bullet icon
+├── about/         Benefits cards, Who-is-GDG mascots/decor, spiral
+├── id/            GDG ID card page assets (spirals, card layers, decor)
+├── team/          Team decorator images + all member photos
+├── partners/      Sponsor/partner logos
+└── auth/          Sparky, default avatar, signin screen assets
+```
+
+**Naming convention:** `[feature]-[subgroup]-[description].ext` (all lowercase kebab-case)
+
+**Format rule:** Raster images → `.webp`. Vector logos/icons → `.svg`.
+
+---
+
+## Using an Asset in a Component
+
+```tsx
+import { ASSETS } from "@/lib/constants/assets";
+import Image from "next/image";
+
+// ✅ Correct
+<Image src={ASSETS.BRANDING.GDG_LOGO_WEBP} alt="GDG Logo" width={40} height={40} />
+
+// ❌ Never do this
+<Image src="/branding/gdg-logo.webp" alt="GDG Logo" width={40} height={40} />
+```
+
+---
+
+## ASSETS Reference
+
+### `ASSETS.BRANDING`
+
+| Key | File | Used in |
+|---|---|---|
+| `GDG_LOGO_SVG` | `/branding/gdg-logo-animated.svg` | `loader.tsx` |
+| `GDG_LOGO_WEBP` | `/branding/gdg-logo.webp` | `Navbar`, `Footer` |
+
+---
+
+### `ASSETS.HOME`
+
+| Key | File | Used in |
+|---|---|---|
+| `HERO.LAYER_SPARKY` | `/home/home-hero-layer-sparky.webp` | `hero-section` |
+| `HERO.LAYER_BG` | `/home/home-hero-layer-bg.webp` | `hero-section`, `HistorySection` |
+| `HERO.LAYER_B1` … `LAYER_F5` | `/home/home-hero-layer-*.webp` | `hero-section` (parallax layers) |
+| `WHO.SPARKY_CIRBY` | `/home/home-who-sparky-cirby.webp` | `who-are-we-section` |
+| `BULLET_DIAMOND` | `/home/home-bullet-diamond.svg` | `what-drives-us`, `spark-starts-here` |
+
+---
+
+### `ASSETS.ABOUT`
+
+| Key | File |
+|---|---|
+| `BENEFITS.GOOGLE_ACCESS` | `/about/about-benefits-google-access.webp` |
+| `BENEFITS.HANDS_ON` | `/about/about-benefits-hands-on.webp` |
+| `BENEFITS.MENTORSHIP` | `/about/about-benefits-mentorship.webp` |
+| `BENEFITS.GROWTH_NETWORK` | `/about/about-benefits-growth-network.webp` |
+| `BENEFITS.LEADERSHIP` | `/about/about-benefits-leadership.webp` |
+| `BENEFITS.COMMUNITY` | `/about/about-benefits-community.webp` |
+| `BENEFITS.DECOR_LEFT` | `/about/about-benefits-decor-left.svg` |
+| `BENEFITS.DECOR_RIGHT` | `/about/about-benefits-decor-right.svg` |
+| `WHO.MASCOT_1` | `/about/about-who-mascot-1.webp` |
+| `WHO.MASCOT_2` | `/about/about-who-mascot-2.webp` |
+| `WHO.SPIRAL` | `/about/about-who-spiral.webp` |
+| `WHO.CARD_BULLET` | `/about/about-who-card-bullet.webp` |
+| `WHO.DECOR_ELEMENT_1` | `/about/about-who-decor-element-1.webp` |
+| `WHO.DECOR_ELEMENT_2` | `/about/about-who-decor-element-2.webp` |
+
+---
+
+### `ASSETS.ID`
+
+| Key | File |
+|---|---|
+| `BG` | `/id/id-bg.webp` |
+| `CIRBY` | `/id/id-cirby.webp` |
+| `DECOR_LEFT` / `DECOR_RIGHT` | `/id/id-decor-left.webp`, `/id/id-decor-right.webp` |
+| `CARD_NAME_FRAME` | `/id/id-card-name-frame.webp` |
+| `CARD_SPARKY` | `/id/id-card-sparky.webp` |
+| `CARD_TEXTURE` | `/id/id-card-texture.webp` |
+| `GETID_RECT_BLUE/GREEN/RED/YELLOW` | `/id/id-getid-rect-*.webp` |
+| `SPIRAL_OUTER/CENTER/INNER` | `/id/id-spiral-*.webp` |
+
+---
+
+### `ASSETS.TEAM`
+
+**Shared decorators:**
+
+| Key | File |
+|---|---|
+| `MASCOT` | `/team/team-mascot.webp` |
+| `STAR` | `/team/team-star.webp` |
+| `HERO_ICON` | `/team/team-hero-icon.webp` |
+| `ELLIPSE_UPPER` / `ELLIPSE_LOWER` | `/team/team-ellipse-upper.webp`, `/team/team-ellipse-lower.webp` |
+
+**Member photos** are grouped by department sub-object, e.g.:
+
+```tsx
+ASSETS.TEAM.ADMINISTRATIVE.RANDY_CARLO_LORENZO
+ASSETS.TEAM.COMMUNITY_RELATIONS.ERICA_MALLARI
+ASSETS.TEAM.WEB_DEVELOPMENT.GERALD_BERONGOY
+// ... etc for all 14 departments
+```
+
+All member photos follow the pattern: `/team/team-<dept>-<member-name>.webp`
+
+---
+
+### `ASSETS.PARTNERS`
+
+| Key | File |
+|---|---|
+| `ACADARENA` … `GEN_AI_PH` | `/partners/partner-<name>.webp` |
+| `CIRBY_STICKER` | `/partners/partner-cirby-sticker.webp` |
+
+---
+
+### `ASSETS.AUTH`
+
+| Key | File |
+|---|---|
+| `SPARKY` | `/auth/auth-sparky.webp` |
+| `AVATAR_DEFAULT` | `/auth/auth-avatar-default.webp` |
+| `SIGNIN_LOGO` | `/auth/auth-signin-logo.webp` |
+| `SIGNIN_HORIZON` | `/auth/auth-signin-horizon.webp` |
+
+---
+
+## Adding a New Asset
+
+1. **Place the file** in the appropriate `public/<feature>/` folder using the naming convention: `[feature]-[subgroup]-[description].webp` (convert to WebP if raster).
+
+2. **Add a constant** in `src/lib/constants/assets.ts` under the matching section:
+
+    ```ts
+    // Example: new team member
+    TEAM: {
+      WEB_DEVELOPMENT: {
+        ...
+        NEW_MEMBER_NAME: "/team/team-web-development-new-member-name.webp",
+      },
+    }
+    ```
+
+3. **Use the constant** in your component — never the raw string.
+
+4. **Verify** the file exists at the declared path:
+
+    ```bash
+    npx tsx scripts/check-assets.ts   # or run the node one-liner:
+    node -e "
+      const fs = require('fs');
+      const c = fs.readFileSync('src/lib/constants/assets.ts','utf-8');
+      const missing = [...c.matchAll(/\"(\/[^\"]+\.(webp|svg|png|jpg))\"/g)]
+        .map(m=>m[1]).filter(p=>!fs.existsSync('public'+p));
+      missing.forEach(p=>console.log('MISSING:',p));
+      console.log('Missing:',missing.length);
+    "
+    ```
+
+---
+
+## Converting Images to WebP
+
+Use **ffmpeg** (installed on dev machines):
+
+```bash
+# Single file
+ffmpeg -y -i input.png -quality 90 output.webp
+
+# Batch convert all PNG in a folder
+for f in public/team/*.png; do
+  ffmpeg -y -i "$f" -quality 90 "${f%.png}.webp" && rm "$f"
+done
+```
+
+---
+
+## After Moving or Renaming Assets
+
+Always clear the Next.js cache before restarting — otherwise stale 404s will persist:
+
+```bash
+rm -rf .next && pnpm dev
+```
+
+See [`bug-assets-not-rendering.md`](../../apps/nexus-web/bug-assets-not-rendering.md) for full details on this gotcha.
+
+---
+
+**[⬅️ Previous: Frontend Development](./6-FrontendDevelopment.md)** | **[Back to Onboarding](./README.md)** | **[Next: Development Workflow ➡️](./7-DevelopmentWorkflow.md)**
+

--- a/docs/Onboarding/7-DevelopmentWorkflow.md
+++ b/docs/Onboarding/7-DevelopmentWorkflow.md
@@ -1,4 +1,4 @@
-**[⬅️ Previous: Frontend Development](./6-FrontendDevelopment.md)** | **[Back to Onboarding](./README.md)** | **[Next: Best Practices ➡️](./99.1-BestPractices.md)**
+**[⬅️ Previous: Public Assets](./6.1-PublicAssets.md)** | **[Back to Onboarding](./README.md)** | **[Next: Best Practices ➡️](./99.1-BestPractices.md)**
 
 ---
 


### PR DESCRIPTION
## Summary
This PR adds a comprehensive developer guide for managing public assets in the project. Previously, there was no centralized documentation for the asset system, leading to inconsistent usage patterns and potential errors when working with images and other static files.

## Strategies
- Added a detailed onboarding document (`docs/Onboarding/6.1-PublicAssets.md`) covering the core principle of centralizing asset paths in the `ASSETS` object
- Documented directory structure, naming conventions, and format standards to ensure consistency across the project
- Included reference tables for each asset group with key names, file paths, and usage locations for easy lookup
- Provided scripts and CLI examples for verifying asset existence and converting images to WebP format

## Additional Information
- Covers step-by-step instructions for adding and referencing assets in components
- Includes troubleshooting guidance for cache issues after moving or renaming assets with links to further documentation
- No functional code changes — documentation only