### PR TITLE
chore: refactor auth provider to use the api endpoint without missing slash

### DIFF
--- a/apps/nexus-web/src/app/(auth)/auth/callback/page.tsx
+++ b/apps/nexus-web/src/app/(auth)/auth/callback/page.tsx
@@ -37,7 +37,7 @@ function AuthCallbackContent() {
         if (accessToken) {
           // Verify with backend
           const response = await fetch(
-            `${NEXUS_API_URL}api/auth-system/exchange`,
+            `${NEXUS_API_URL}/api/v1/auth-system/exchange`,
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -136,7 +136,7 @@ function AuthCallbackContent() {
 
         // Exchange code for session
         const response = await fetch(
-          `${NEXUS_API_URL}api/auth-system/exchange`,
+          `${NEXUS_API_URL}/api/v1/auth-system/exchange`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/apps/nexus-web/src/app/(auth)/auth/confirm/page.tsx
+++ b/apps/nexus-web/src/app/(auth)/auth/confirm/page.tsx
@@ -35,7 +35,7 @@ function ConfirmPageContent() {
         }
 
         // Call backend API to verify
-        const url = `${NEXUS_API_URL}api/auth-system/verify`;
+        const url = `${NEXUS_API_URL}/api/v1/auth-system/verify`;
         console.log("Calling API:", url);
 
         const response = await fetch(url, {

--- a/apps/nexus-web/src/providers/AuthProvider.tsx
+++ b/apps/nexus-web/src/providers/AuthProvider.tsx
@@ -124,7 +124,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       // Fetch current user from backend
-      const response = await fetch(`${NEXUS_API_URL}api/auth-system/me`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/me`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -175,7 +175,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       setAuthState((prev) => ({ ...prev, error: null }));
 
-      const response = await fetch(`${NEXUS_API_URL}api/auth-system/signup`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/signup`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ data: { email, password } }),
@@ -209,7 +209,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       setAuthState((prev) => ({ ...prev, error: null }));
 
-      const response = await fetch(`${NEXUS_API_URL}api/auth-system/signin`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/signin`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ data: { email, password } }),
@@ -242,7 +242,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setAuthState((prev) => ({ ...prev, error: null }));
 
       // Call backend to initiate OAuth
-      const response = await fetch(`${NEXUS_API_URL}api/auth-system/oauth`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/oauth`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -279,7 +279,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       // 1. Call backend to invalidate session (if we have a token)
       if (authState.token) {
-        await fetch(`${NEXUS_API_URL}api/auth-system/logout`, {
+        await fetch(`${NEXUS_API_URL}/api/auth-system/logout`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/apps/nexus-web/src/providers/AuthProvider.tsx
+++ b/apps/nexus-web/src/providers/AuthProvider.tsx
@@ -124,7 +124,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       // Fetch current user from backend
-      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/me`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/v1/auth-system/me`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -175,7 +175,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       setAuthState((prev) => ({ ...prev, error: null }));
 
-      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/signup`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/v1/auth-system/signup`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ data: { email, password } }),
@@ -209,7 +209,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       setAuthState((prev) => ({ ...prev, error: null }));
 
-      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/signin`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/v1/auth-system/signin`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ data: { email, password } }),
@@ -242,7 +242,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setAuthState((prev) => ({ ...prev, error: null }));
 
       // Call backend to initiate OAuth
-      const response = await fetch(`${NEXUS_API_URL}/api/auth-system/oauth`, {
+      const response = await fetch(`${NEXUS_API_URL}/api/v1/auth-system/oauth`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -279,7 +279,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       // 1. Call backend to invalidate session (if we have a token)
       if (authState.token) {
-        await fetch(`${NEXUS_API_URL}/api/auth-system/logout`, {
+        await fetch(`${NEXUS_API_URL}/api/v1/auth-system/logout`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
This pull request fixes several API endpoint URLs in the `AuthProvider` component to ensure proper communication with the backend authentication system. The main change is adding a missing slash (`/`) between the base API URL and the endpoint path, which resolves issues with incorrect endpoint formatting.

Authentication endpoint URL fixes:

* Corrected the URL for fetching the current user by adding a slash, changing from `${NEXUS_API_URL}api/auth-system/me` to `${NEXUS_API_URL}/api/auth-system/me`.
* Fixed the signup endpoint URL to include a slash, updating from `${NEXUS_API_URL}api/auth-system/signup` to `${NEXUS_API_URL}/api/auth-system/signup`.
* Updated the signin endpoint URL to include a slash, changing from `${NEXUS_API_URL}api/auth-system/signin` to `${NEXUS_API_URL}/api/auth-system/signin`.
* Corrected the OAuth initiation endpoint URL by adding a slash, updating from `${NEXUS_API_URL}api/auth-system/oauth` to `${NEXUS_API_URL}/api/auth-system/oauth`.
* Fixed the logout endpoint URL to include a slash, changing from `${NEXUS_API_URL}api/auth-system/logout` to `${NEXUS_API_URL}/api/auth-system/logout`.

Closes #420