### PR TITLE
fix: next not loading images from googleusercontent.com 

### DIFF
--- a/apps/nexus-admin-web/next.config.ts
+++ b/apps/nexus-admin-web/next.config.ts
@@ -13,6 +13,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "*.supabase.co",
       },
+      {
+        protocol: "https",
+        hostname: "*.googleusercontent.com",
+      },
     ],
   },
 };

--- a/apps/nexus-web/next.config.ts
+++ b/apps/nexus-web/next.config.ts
@@ -13,6 +13,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "*.supabase.co",
       },
+      {
+        protocol: "https",
+        hostname: "*.googleusercontent.com",
+      },
     ],
   },
 };


### PR DESCRIPTION
# summary 
added googleusercontent.com on allowed static origin on nexus-web and nexus-admin-web