### PR TITLE
feat(nexus-api): add zeptomail email service for automated mails

### DIFF
--- a/apps/nexus-api/package.json
+++ b/apps/nexus-api/package.json
@@ -43,6 +43,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "tsc-alias": "^1.8.16",
+    "zeptomail": "^7.0.2",
     "zod": "^4.3.5",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/apps/nexus-api/src/configs/configs.ts
+++ b/apps/nexus-api/src/configs/configs.ts
@@ -11,4 +11,12 @@ export const configs = {
     secret: process.env.JWT_SECRET || "secret",
     expiresIn: process.env.JWT_EXPIRES_IN || "1h",
   },
+  zeptoMail: {
+    url: process.env.ZEPTOMAIL_URL || "https://api.zeptomail.com/v1.1/email",
+    token: process.env.ZEPTOMAIL_TOKEN || "",
+    from: {
+      address: process.env.ZEPTOMAIL_FROM_ADDRESS || "noreply@gdgpup.org",
+      name: process.env.ZEPTOMAIL_FROM_NAME || "GDG PUP",
+    },
+  },
 };

--- a/apps/nexus-api/src/v1/modules/mailer/README.md
+++ b/apps/nexus-api/src/v1/modules/mailer/README.md
@@ -1,0 +1,45 @@
+# Mailer Module
+
+The Mailer module is responsible for sending emails across the GDG PUP Platform. It follows a clean architecture pattern with a pluggable infrastructure.
+
+## Architecture
+
+- **Domain**: Defines the `Email` entity and `IMailerService` interface.
+- **Use Cases**: Contains `SendEmail` which orchestrates the sending process.
+- **Infrastructure**:
+  - `MockMailerService`: Logs emails to the console (default for development).
+  - `ZeptoMailerService`: Sends real emails using the ZeptoMail API.
+- **Templates**: Contains HTML email templates like `OtpEmailTemplate`.
+
+## Configuration
+
+The mailer service is configured in `src/configs/configs.ts`. It automatically switches to `ZeptoMailerService` if a `ZEPTOMAIL_TOKEN` is provided in the environment variables.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ZEPTOMAIL_TOKEN` | Your ZeptoMail API Key | (Empty, triggers Mock) |
+| `ZEPTOMAIL_URL` | ZeptoMail API Endpoint | `https://api.zeptomail.com/v1.1/email` |
+| `ZEPTOMAIL_FROM_ADDRESS` | Sender email address | `noreply@gdgpup.org` |
+| `ZEPTOMAIL_FROM_NAME` | Sender display name | `GDG PUP` |
+
+## Usage
+
+```typescript
+import { mailerController, OtpEmailTemplate } from "@/v1/modules/mailer";
+
+// Using the controller
+await mailerController.sendEmail(
+  "user@example.com",
+  "Verification Code",
+  OtpEmailTemplate.render("123456")
+);
+```
+
+## Email Templates
+
+Templates are located in `src/v1/modules/mailer/templates/`. They are optimized for:
+- **Light/Dark Mode**: Automatic theme detection.
+- **Pure White Theme**: Clean high-contrast look for light mode.
+- **GDG Branding**: Rainbow headers and brand colors.

--- a/apps/nexus-api/src/v1/modules/mailer/__tests__/OtpEmailTemplate.test.ts
+++ b/apps/nexus-api/src/v1/modules/mailer/__tests__/OtpEmailTemplate.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { OtpEmailTemplate } from "../templates/OtpEmailTemplate";
+
+describe("OtpEmailTemplate", () => {
+  it("should render the OTP code in the HTML", () => {
+    const otp = "123456";
+    const html = OtpEmailTemplate.render(otp);
+    
+    expect(html).toContain(otp);
+    expect(html).toContain("Google Developers Group");
+    expect(html).toContain("Verification Code");
+  });
+
+  it("should contain GDG branding colors", () => {
+    const html = OtpEmailTemplate.render("123456");
+    
+    expect(html).toContain("#4285F4"); // Blue
+    expect(html).toContain("#EA4335"); // Red
+    expect(html).toContain("#FBBC05"); // Yellow
+    expect(html).toContain("#34A853"); // Green
+  });
+});

--- a/apps/nexus-api/src/v1/modules/mailer/index.ts
+++ b/apps/nexus-api/src/v1/modules/mailer/index.ts
@@ -1,8 +1,13 @@
 import { MockMailerService } from "./infrastructure/MockMailerService";
+import { ZeptoMailerService } from "./infrastructure/ZeptoMailerService";
 import { SendEmail } from "./useCases/SendEmail";
 import { MailerController } from "./MailerController";
+import { configs } from "@/configs/configs";
 
-const mailerService = new MockMailerService();
+const mailerService = configs.zeptoMail.token
+  ? new ZeptoMailerService()
+  : new MockMailerService();
+
 const sendEmailUseCase = new SendEmail(mailerService);
 
 export const mailerController = new MailerController(sendEmailUseCase);
@@ -11,3 +16,4 @@ export { MailerController };
 export * from "./domain/Email";
 export * from "./domain/IMailerService";
 export * from "./useCases/SendEmail";
+export * from "./templates/OtpEmailTemplate";

--- a/apps/nexus-api/src/v1/modules/mailer/infrastructure/ZeptoMailerService.ts
+++ b/apps/nexus-api/src/v1/modules/mailer/infrastructure/ZeptoMailerService.ts
@@ -1,0 +1,48 @@
+import { SendMailClient } from "zeptomail";
+import { IMailerService } from "../domain/IMailerService";
+import { Email } from "../domain/Email";
+import { configs } from "@/configs/configs";
+
+export class ZeptoMailerService implements IMailerService {
+  private client: SendMailClient;
+
+  constructor() {
+    this.client = new SendMailClient({
+      url: configs.zeptoMail.url,
+      token: configs.zeptoMail.token,
+    });
+  }
+
+  async send(email: Email): Promise<void> {
+    const { to, subject, message } = email.props;
+
+    // Only send if token is present, otherwise log it (to prevent breaking dev)
+    if (!configs.zeptoMail.token) {
+      console.warn("⚠️ [ZeptoMailerService] No ZEPTOMAIL_TOKEN found. Email not sent.");
+      console.log(`To: ${to}\nSubject: ${subject}\nMessage: ${message}`);
+      return;
+    }
+
+    try {
+      await this.client.sendMail({
+        from: {
+          address: configs.zeptoMail.from.address,
+          name: configs.zeptoMail.from.name,
+        },
+        to: [
+          {
+            email_address: {
+              address: to,
+              name: to.split("@")[0],
+            },
+          },
+        ],
+        subject: subject,
+        htmlbody: message,
+      });
+    } catch (error) {
+      console.error("❌ [ZeptoMailerService] Error sending email:", error);
+      throw new Error("Failed to send email via ZeptoMail.");
+    }
+  }
+}

--- a/apps/nexus-api/src/v1/modules/mailer/templates/OtpEmailTemplate.ts
+++ b/apps/nexus-api/src/v1/modules/mailer/templates/OtpEmailTemplate.ts
@@ -1,0 +1,176 @@
+export class OtpEmailTemplate {
+  static render(otp: string): string {
+    // GDG Brand Colors
+    const gdgColors = {
+      blue: "#4285F4",
+      red: "#EA4335",
+      yellow: "#FBBC04",
+      green: "#34A853",
+    };
+
+    // UI Colors
+    const uiColors = {
+      cyan: "#57CAFF",
+      white: "#F0F8FF",
+      navy: "#000614",
+    };
+
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <title>Verification Code | GDG on Campus PUP</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    
+    @media only screen and (max-width: 600px) {
+      .main-table { width: 100% !important; }
+      .content-padding { padding: 24px 16px !important; }
+      .header-padding { padding: 32px 16px 16px 16px !important; }
+      .footer-padding { padding: 20px 16px !important; }
+    }
+    
+    /* Light mode (pure white) */
+    .body-bg { background-color: #ffffff !important; }
+    .main-card { background: #ffffff !important; border: 1px solid #f0f0f0 !important; }
+    .header-bg { background: linear-gradient(180deg, rgba(66,133,244,0.05), transparent) !important; }
+    .content-card { background: #ffffff !important; border: 1px solid #f0f0f0 !important; }
+    .heading-text { color: #1a1a1a !important; }
+    .body-text { color: #333333 !important; }
+    .otp-bg { background: #ffffff !important; border: 1px dashed ${gdgColors.blue} !important; }
+    .footer-bg { background: #ffffff !important; }
+    
+    /* Dark mode */
+    @media (prefers-color-scheme: dark) {
+      .body-bg { background: #000614 !important; }
+      .main-card { background: #020d28 !important; border: 1px solid rgba(87,202,255,0.1) !important; }
+      .header-bg { background: linear-gradient(180deg, rgba(87,202,255,0.12), transparent) !important; }
+      .content-card { background: rgba(87,202,255,0.08) !important; border: 1px solid rgba(87,202,255,0.1) !important; }
+      .heading-text { color: #ffffff !important; }
+      .body-text { color: rgba(255, 255, 255, 0.85) !important; }
+      .otp-bg { background: rgba(87,202,255,0.05) !important; border: 1px dashed ${uiColors.cyan} !important; }
+      .footer-bg { background: rgba(0, 6, 20, 0.6) !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Segoe UI', Roboto, Arial, sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="body-bg" style="background-color: #ffffff;">
+    <tr>
+      <td align="center" style="padding: 20px 12px;">
+        <table role="presentation" width="600" cellspacing="0" cellpadding="0" class="main-table main-card" style="background: #ffffff; border-radius: 24px; overflow: hidden; box-shadow: 0 20px 40px rgba(0, 0, 0, 0.05);">
+          
+          <!-- GDG Brand Header -->
+          <tr>
+            <td style="padding: 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.blue};"></td>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.red};"></td>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.yellow};"></td>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.green};"></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          
+          <!-- Header -->
+          <tr>
+            <td align="center" class="header-padding header-bg" style="padding: 40px 24px 16px 24px;">
+              <h1 class="heading-text" style="margin: 0; font-size: 24px; font-weight: 800; color: #1a1a1a; letter-spacing: -0.5px;">
+                Verification Code
+              </h1>
+              <p style="margin: 8px 0 0 0; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1.5px; color: ${gdgColors.blue};">
+                GDG on Campus PUP
+              </p>
+            </td>
+          </tr>
+          
+          <!-- Content Section -->
+          <tr>
+            <td class="content-padding" style="padding: 24px 40px 32px 40px;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="content-card" style="background: #ffffff; border-radius: 20px; border: 1px solid #f0f0f0;">
+                <tr>
+                  <td style="padding: 32px;" align="center">
+                    <p class="body-text" style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #333333;">
+                      Hello Sparkmate! Use the code below to verify your identity. This code will expire in <strong>10 minutes</strong>.
+                    </p>
+                    
+                    <!-- OTP Display -->
+                    <table role="presentation" cellspacing="0" cellpadding="0" style="margin: 24px 0;">
+                      <tr>
+                        <td class="otp-bg" style="padding: 20px 40px; border-radius: 16px; border: 1px dashed ${gdgColors.blue};">
+                          <p style="margin: 0; font-family: 'Courier New', monospace; font-size: 42px; font-weight: 800; letter-spacing: 8px; color: ${gdgColors.blue}; text-shadow: 0 2px 4px rgba(66,133,244,0.05);">
+                            ${otp}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <p class="body-text" style="margin: 24px 0 0 0; font-size: 14px; color: #666666;">
+                      If you didn't request this code, you can safely ignore this email.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          
+          <!-- Footer -->
+          <tr>
+            <td class="footer-padding footer-bg" style="padding: 32px 24px; background: #ffffff; border-top: 1px solid #f0f0f0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" align="center">
+                <tr>
+                  <td align="center">
+                    <!-- Brand Dots -->
+                    <table role="presentation" cellspacing="0" cellpadding="0" style="margin-bottom: 16px;">
+                      <tr>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.blue};"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.red};"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.yellow};"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.green};"></td>
+                      </tr>
+                    </table>
+                    <p class="muted-text" style="margin: 0; font-size: 12px; font-weight: 600; color: #666666; text-transform: uppercase; letter-spacing: 1px;">
+                      Google Developer Groups <span style="color: ${gdgColors.blue};">on Campus</span> PUP
+                    </p>
+                    <p style="margin: 8px 0 0 0; color: #999999; font-size: 10px; line-height: 1.5;">
+                      Polytechnic University of the Philippines, Manila<br>
+                      © ${new Date().getFullYear()} GDG PUP. All rights reserved.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Bottom Rainbow Bar -->
+          <tr>
+            <td style="padding: 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td width="25%" style="height: 4px; background-color: ${gdgColors.blue};"></td>
+                  <td width="25%" style="height: 4px; background-color: ${gdgColors.red};"></td>
+                  <td width="25%" style="height: 4px; background-color: ${gdgColors.yellow};"></td>
+                  <td width="25%" style="height: 4px; background-color: ${gdgColors.green};"></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+  `.trim();
+  }
+}

--- a/apps/nexus-api/src/v1/modules/oneTimePin/infrastructure/OneTimePinMailerService.ts
+++ b/apps/nexus-api/src/v1/modules/oneTimePin/infrastructure/OneTimePinMailerService.ts
@@ -1,12 +1,12 @@
 import { IOTPMailerService } from "../domain/IOneTimePinInterfaces";
-import { mailerController } from "../../mailer";
+import { mailerController, OtpEmailTemplate } from "../../mailer";
 
 export class OneTimePinMailerService implements IOTPMailerService {
   async sendOtp(email: string, otp: string): Promise<void> {
     await mailerController.sendEmail(
       email,
       "Your OTP Code",
-      `Your verification code is: ${otp}. It will expire in 10 minutes.`
+      OtpEmailTemplate.render(otp)
     );
   }
 }

--- a/email-preview.html
+++ b/email-preview.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <title>Verification Code | GDG on Campus PUP</title>
+  <style>
+    :root { color-scheme: light dark; }
+    @media only screen and (max-width: 600px) {
+      .main-table { width: 100% !important; }
+      .content-padding { padding: 24px 16px !important; }
+      .header-padding { padding: 32px 16px 16px 16px !important; }
+      .footer-padding { padding: 20px 16px !important; }
+    }
+    /* Light mode */
+    .body-bg { background-color: #f0f4ff !important; }
+    .main-card { background: #ffffff !important; }
+    .header-bg { background: linear-gradient(180deg, rgba(66,133,244,0.08), transparent) !important; }
+    .content-card { background: rgba(66,133,244,0.03) !important; border: 1px solid rgba(66,133,244,0.1) !important; }
+    .heading-text { color: #1a1a1a !important; }
+    .body-text { color: #333333 !important; }
+    .otp-bg { background: #f8faff !important; border: 1px dashed #4285F4 !important; }
+    .footer-bg { background: #f8faff !important; }
+    
+    /* Dark mode */
+    @media (prefers-color-scheme: dark) {
+      .body-bg { background: #000614 !important; }
+      .main-card { background: #020d28 !important; border: 1px solid rgba(87,202,255,0.1) !important; }
+      .header-bg { background: linear-gradient(180deg, rgba(87,202,255,0.12), transparent) !important; }
+      .content-card { background: rgba(87,202,255,0.08) !important; border: 1px solid rgba(87,202,255,0.1) !important; }
+      .heading-text { color: #ffffff !important; }
+      .body-text { color: rgba(255, 255, 255, 0.85) !important; }
+      .otp-bg { background: rgba(87,202,255,0.05) !important; border: 1px dashed #57CAFF !important; }
+      .footer-bg { background: rgba(0, 6, 20, 0.4) !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="body-bg" style="background-color: #f0f4ff;">
+    <tr>
+      <td align="center" style="padding: 20px 12px;">
+        <table role="presentation" width="600" cellspacing="0" cellpadding="0" class="main-table main-card" style="background: #ffffff; border-radius: 24px; overflow: hidden; box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);">
+          <tr>
+            <td style="padding: 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td width="25%" style="height: 6px; background-color: #4285F4;"></td>
+                  <td width="25%" style="height: 6px; background-color: #EA4335;"></td>
+                  <td width="25%" style="height: 6px; background-color: #FBBC04;"></td>
+                  <td width="25%" style="height: 6px; background-color: #34A853;"></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" class="header-padding header-bg" style="padding: 40px 24px 16px 24px;">
+              <h1 class="heading-text" style="margin: 0; font-size: 24px; font-weight: 800; color: #1a1a1a;">Verification Code</h1>
+              <p style="margin: 8px 0 0 0; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1.5px; color: #4285F4;">GDG on Campus PUP</p>
+            </td>
+          </tr>
+          <tr>
+            <td class="content-padding" style="padding: 24px 40px 32px 40px;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="content-card" style="background: rgba(66,133,244,0.03); border-radius: 20px; border: 1px solid rgba(66,133,244,0.1);">
+                <tr>
+                  <td style="padding: 32px;" align="center">
+                    <p class="body-text" style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #333333;">Hello Sparkmate! Use the code below to verify your identity. This code will expire in <strong>10 minutes</strong>.</p>
+                    <table role="presentation" cellspacing="0" cellpadding="0" style="margin: 24px 0;">
+                      <tr>
+                        <td class="otp-bg" style="padding: 20px 40px; border-radius: 16px; border: 1px dashed #4285F4;">
+                          <p style="margin: 0; font-family: 'Courier New', monospace; font-size: 42px; font-weight: 800; letter-spacing: 8px; color: #4285F4;">
+                            984251
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                    <p class="body-text" style="margin: 24px 0 0 0; font-size: 14px; color: #666666;">If you didn't request this code, you can safely ignore this email.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="footer-padding footer-bg" style="padding: 32px 24px; background: #f8faff; border-top: 1px solid rgba(0, 0, 0, 0.05);">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" align="center">
+                <tr>
+                  <td align="center">
+                    <table role="presentation" cellspacing="0" cellpadding="0" style="margin-bottom: 16px;">
+                      <tr>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: #4285F4;"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: #EA4335;"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: #FBBC04;"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: #34A853;"></td>
+                      </tr>
+                    </table>
+                    <p class="muted-text" style="margin: 0; font-size: 12px; font-weight: 600; color: #666666; text-transform: uppercase; letter-spacing: 1px;">Google Developer Groups <span style="color: #4285F4;">on Campus</span> PUP</p>
+                    <p style="margin: 8px 0 0 0; color: #999999; font-size: 10px;">Polytechnic University of the Philippines, Manila<br>© 2026 GDG PUP. All rights reserved.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,7 +222,7 @@ importers:
         version: 12.35.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ogl:
         specifier: ^1.0.11
         version: 1.0.11
@@ -353,6 +353,9 @@ importers:
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
+      zeptomail:
+        specifier: ^7.0.2
+        version: 7.0.2
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -479,7 +482,7 @@ importers:
         version: 12.35.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ogl:
         specifier: ^1.0.11
         version: 1.0.11
@@ -546,7 +549,7 @@ importers:
         version: link:../../packages/spark-ui
       next:
         specifier: 16.1.5
-        version: 16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -571,7 +574,7 @@ importers:
         version: 10.2.16(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.18)
       '@storybook/nextjs-vite':
         specifier: ^10.2.0
-        version: 10.2.16(esbuild@0.27.3)(next@16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.16(@babel/core@7.29.0)(esbuild@0.27.3)(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.1
@@ -7911,6 +7914,9 @@ packages:
     engines: {node: '>=8.0.0'}
     hasBin: true
 
+  zeptomail@7.0.2:
+    resolution: {integrity: sha512-bolBpUJoQgaMoYU5vE8vWuMGlRljtLH31hIhK4R3WpkEZZA1s5DZG3tVc93FQ4SiFbAZsMNvMZiggeQ8Ukk5dA==}
+
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
@@ -9494,18 +9500,18 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/nextjs-vite@10.2.16(esbuild@0.27.3)(next@16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/nextjs-vite@10.2.16(@babel/core@7.29.0)(esbuild@0.27.3)(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@storybook/builder-vite': 10.2.16(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/react': 10.2.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite': 10.2.16(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      next: 16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
       vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-storybook-nextjs: 3.2.2(next@16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      vite-plugin-storybook-nextjs: 3.2.2(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10953,7 +10959,7 @@ snapshots:
   cookies-next@6.1.1(next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       cookie: 1.1.1
-      next: 16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   cors@2.8.6:
@@ -11390,8 +11396,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -11410,8 +11416,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.5
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -11437,7 +11443,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -11448,21 +11454,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11473,7 +11479,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13821,7 +13827,7 @@ snapshots:
 
   neotraverse@0.6.15: {}
 
-  next@16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -13846,7 +13852,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.5
       '@swc/helpers': 0.5.15
@@ -15838,13 +15844,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-storybook-nextjs@3.2.2(next@16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-storybook-nextjs@3.2.2(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.1.5(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 10.2.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -16191,6 +16197,12 @@ snapshots:
       validator: 13.15.26
     optionalDependencies:
       commander: 9.5.0
+
+  zeptomail@7.0.2:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:

--- a/scripts/preview-email.ts
+++ b/scripts/preview-email.ts
@@ -1,0 +1,139 @@
+import fs from 'fs';
+
+// Standalone template for preview to avoid module resolution issues in script
+class OtpEmailTemplate {
+  static render(otp: string): string {
+    const gdgColors = {
+      blue: "#4285F4",
+      red: "#EA4335",
+      yellow: "#FBBC04",
+      green: "#34A853",
+    };
+
+    const uiColors = {
+      cyan: "#57CAFF",
+      white: "#F0F8FF",
+    };
+
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <title>Verification Code | GDG on Campus PUP</title>
+  <style>
+    :root { color-scheme: light dark; }
+    @media only screen and (max-width: 600px) {
+      .main-table { width: 100% !important; }
+      .content-padding { padding: 24px 16px !important; }
+      .header-padding { padding: 32px 16px 16px 16px !important; }
+      .footer-padding { padding: 20px 16px !important; }
+    }
+    /* Light mode */
+    .body-bg { background-color: #f0f4ff !important; }
+    .main-card { background: #ffffff !important; }
+    .header-bg { background: linear-gradient(180deg, rgba(66,133,244,0.08), transparent) !important; }
+    .content-card { background: rgba(66,133,244,0.03) !important; border: 1px solid rgba(66,133,244,0.1) !important; }
+    .heading-text { color: #1a1a1a !important; }
+    .body-text { color: #333333 !important; }
+    .otp-bg { background: #f8faff !important; border: 1px dashed ${gdgColors.blue} !important; }
+    .footer-bg { background: #f8faff !important; }
+    
+    /* Dark mode */
+    @media (prefers-color-scheme: dark) {
+      .body-bg { background: #000614 !important; }
+      .main-card { background: #020d28 !important; border: 1px solid rgba(87,202,255,0.1) !important; }
+      .header-bg { background: linear-gradient(180deg, rgba(87,202,255,0.12), transparent) !important; }
+      .content-card { background: rgba(87,202,255,0.08) !important; border: 1px solid rgba(87,202,255,0.1) !important; }
+      .heading-text { color: #ffffff !important; }
+      .body-text { color: rgba(255, 255, 255, 0.85) !important; }
+      .otp-bg { background: rgba(87,202,255,0.05) !important; border: 1px dashed ${uiColors.cyan} !important; }
+      .footer-bg { background: rgba(0, 6, 20, 0.4) !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="body-bg" style="background-color: #f0f4ff;">
+    <tr>
+      <td align="center" style="padding: 20px 12px;">
+        <table role="presentation" width="600" cellspacing="0" cellpadding="0" class="main-table main-card" style="background: #ffffff; border-radius: 24px; overflow: hidden; box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);">
+          <tr>
+            <td style="padding: 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.blue};"></td>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.red};"></td>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.yellow};"></td>
+                  <td width="25%" style="height: 6px; background-color: ${gdgColors.green};"></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" class="header-padding header-bg" style="padding: 40px 24px 16px 24px;">
+              <h1 class="heading-text" style="margin: 0; font-size: 24px; font-weight: 800; color: #1a1a1a;">Verification Code</h1>
+              <p style="margin: 8px 0 0 0; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1.5px; color: ${gdgColors.blue};">GDG on Campus PUP</p>
+            </td>
+          </tr>
+          <tr>
+            <td class="content-padding" style="padding: 24px 40px 32px 40px;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="content-card" style="background: rgba(66,133,244,0.03); border-radius: 20px; border: 1px solid rgba(66,133,244,0.1);">
+                <tr>
+                  <td style="padding: 32px;" align="center">
+                    <p class="body-text" style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #333333;">Hello Sparkmate! Use the code below to verify your identity. This code will expire in <strong>10 minutes</strong>.</p>
+                    <table role="presentation" cellspacing="0" cellpadding="0" style="margin: 24px 0;">
+                      <tr>
+                        <td class="otp-bg" style="padding: 20px 40px; border-radius: 16px; border: 1px dashed ${gdgColors.blue};">
+                          <p style="margin: 0; font-family: 'Courier New', monospace; font-size: 42px; font-weight: 800; letter-spacing: 8px; color: ${gdgColors.blue};">
+                            ${otp}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                    <p class="body-text" style="margin: 24px 0 0 0; font-size: 14px; color: #666666;">If you didn't request this code, you can safely ignore this email.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="footer-padding footer-bg" style="padding: 32px 24px; background: #f8faff; border-top: 1px solid rgba(0, 0, 0, 0.05);">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" align="center">
+                <tr>
+                  <td align="center">
+                    <table role="presentation" cellspacing="0" cellpadding="0" style="margin-bottom: 16px;">
+                      <tr>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.blue};"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.red};"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.yellow};"></td>
+                        <td style="width: 8px;"></td>
+                        <td style="width: 8px; height: 8px; border-radius: 50%; background-color: ${gdgColors.green};"></td>
+                      </tr>
+                    </table>
+                    <p class="muted-text" style="margin: 0; font-size: 12px; font-weight: 600; color: #666666; text-transform: uppercase; letter-spacing: 1px;">Google Developer Groups <span style="color: ${gdgColors.blue};">on Campus</span> PUP</p>
+                    <p style="margin: 8px 0 0 0; color: #999999; font-size: 10px;">Polytechnic University of the Philippines, Manila<br>© ${new Date().getFullYear()} GDG PUP. All rights reserved.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+`.trim();
+  }
+}
+
+const previewContent = OtpEmailTemplate.render('984251');
+fs.writeFileSync('email-preview.html', previewContent);
+
+console.log('✅ Preview generated: email-preview.html');
+console.log('Open this file in your browser to see the light/dark mode design.');


### PR DESCRIPTION
# PR Description: ZeptoMail Integration & Brand OTP Template

## Description
This PR integrates **ZeptoMail** as the primary email service provider for the Nexus API. It also introduces a high-fidelity, dual-mode (Light/Dark) **OTP Email Template** following GDG brand guidelines.

The implementation follows **Clean Architecture** principles, allowing the system to seamlessly switch between a `MockMailerService` (for local development) and the `ZeptoMailerService` (for production) based on the presence of environment variables.

## Key Features
- **ZeptoMail Integration**: Added `zeptomail` SDK and implemented `ZeptoMailerService`.
- **Hybrid Mailer Logic**: The system automatically defaults to `MockMailerService` (logging to console) if no API key is provided, preventing breaking changes for local developers.
- **High-Fidelity OTP Template**:
  - **Pure White Theme**: Optimized for a clean, professional look in Light Mode (#ffffff).
  - **Automatic Dark Mode**: CSS overrides for seamless viewing in dark-themed email clients.
  - **GDG Branding**: Includes rainbow headers, brand colors, and official footer styling.
  - **Emoji-Free**: Streamlined professional identity.
- **Preview Tooling**: Added a script to generate a local HTML preview of the email template.

## Technical Changes
- **Infrastructure**: Created `ZeptoMailerService.ts` in the mailer module.
- **Configuration**: Added ZeptoMail configuration keys to `configs.ts`.
- **Templates**: Created `OtpEmailTemplate.ts` with responsive HTML/CSS.
- **Documentation**: Added a dedicated `README.md` to the mailer module and updated `.env.example` files.

## Environment Variables
Add the following to your `.env` file to enable real email sending:
```env
# ZeptoMail Configuration
ZEPTOMAIL_TOKEN="your_zepto_api_key"
ZEPTOMAIL_FROM_ADDRESS="noreply@gdgpup.org"
ZEPTOMAIL_FROM_NAME="GDG PUP"
```

## How to Test
1. **Unit Tests**:
   Run `pnpm vitest run src/v1/modules/mailer/__tests__/OtpEmailTemplate.test.ts` to verify template rendering.
2. **Visual Preview**:
   Run `npx tsx scripts/preview-email.ts` and open the generated `email-preview.html` in your browser.
3. **Integration**:
   Trigger an OTP flow (e.g., login/registration). If `ZEPTOMAIL_TOKEN` is missing, check the console for the logged email. If present, verify receipt in the target inbox.

---
<img width="576" height="592" alt="image" src="https://github.com/user-attachments/assets/c5e44dab-5312-49cb-8b52-3d0dfa08d851" />

<img width="783" height="599" alt="image" src="https://github.com/user-attachments/assets/fe933083-a64d-4db0-b980-80cfb4012e4b" />

<img width="788" height="541" alt="image" src="https://github.com/user-attachments/assets/0f233cc4-19bb-45ab-b0aa-8c076c64115b" />

Closes #554 
