### PR TITLE
feat(scraped-events): add image_square_url column and save it to db

### DIFF
--- a/apps/nexus-api/src/v1/modules/bevyEvents/domain/BevyEvent.ts
+++ b/apps/nexus-api/src/v1/modules/bevyEvents/domain/BevyEvent.ts
@@ -7,6 +7,7 @@ export type BevyEventProps = {
   end_date: string;
   location?: string;
   cover_image_url?: string;
+  image_square_url?: string;
   status?: string;
   event_type?: string;
   created_at?: string;

--- a/apps/nexus-api/src/v1/modules/bevyEvents/infrastructure/SupabaseBevyEventRepository.ts
+++ b/apps/nexus-api/src/v1/modules/bevyEvents/infrastructure/SupabaseBevyEventRepository.ts
@@ -20,6 +20,7 @@ export class SupabaseBevyEventRepository implements IBevyEventRepository {
       end_date: row.end_date,
       location: row.location ?? undefined,
       cover_image_url: row.cover_image_url ?? undefined,
+      image_square_url: row.image_square_url ?? undefined,
       status: row.status ?? undefined,
       event_type: row.event_type ?? undefined,
       created_at: row.created_at ?? undefined,

--- a/apps/nexus-api/src/v1/types/supabase.types.ts
+++ b/apps/nexus-api/src/v1/types/supabase.types.ts
@@ -841,6 +841,7 @@ export type Database = {
           event_type: string | null
           event_type_slug: string | null
           gdg_id: number
+          image_square_url: string | null
           is_virtual_event: boolean | null
           last_scraped_at: string | null
           location: string | null
@@ -864,6 +865,7 @@ export type Database = {
           event_type?: string | null
           event_type_slug?: string | null
           gdg_id: number
+          image_square_url?: string | null
           is_virtual_event?: boolean | null
           last_scraped_at?: string | null
           location?: string | null
@@ -887,6 +889,7 @@ export type Database = {
           event_type?: string | null
           event_type_slug?: string | null
           gdg_id?: number
+          image_square_url?: string | null
           is_virtual_event?: boolean | null
           last_scraped_at?: string | null
           location?: string | null

--- a/scripts/sync-gdg-events.ts
+++ b/scripts/sync-gdg-events.ts
@@ -115,9 +115,9 @@ async function syncEvents() {
       // Prioritize cropped banner if available, otherwise fall back to picture or null
       cover_image_url:
         event.cropped_banner_url ||
-        event.picture?.url ||
         event.cropped_picture_url ||
         null,
+      image_square_url: event.picture.url || event.event_type_logo.url || null,
       status: event.status,
       event_type: event.event_type_title,
       event_type_slug: event.event_type_slug || null,

--- a/supabase/migrations/20260331000000_add_image_square_url_to_scraped_gdg_events.sql
+++ b/supabase/migrations/20260331000000_add_image_square_url_to_scraped_gdg_events.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."scraped_gdg_events" ADD COLUMN "image_square_url" text;


### PR DESCRIPTION
This PR adds the \image_square_url\ column to the \scraped_gdg_events\ table and updates the sync script to populate it. 

### Changes
- Added migration to add \image_square_url\ column to \scraped_gdg_events\.
- Updated \scripts/sync-gdg-events.ts\ to extract \image_square_url\ from the GDG API response.
- Updated domain entities and repositories in \
exus-api\ to handle the new column.
- Updated Supabase types for \
exus-api\.

Closes #603