### PR TITLE
chore: exclude identity-api from build and test steps in CI/CD pipeline

### DIFF
--- a/.github/cicd-plan.md
+++ b/.github/cicd-plan.md
@@ -70,8 +70,8 @@ This document outlines the CI/CD pipeline for the GDG PUP Platform monorepo. The
 |---|---|---|
 | Setup | Node 20, pnpm (cached) | Environment preparation |
 | Install | `pnpm install --frozen-lockfile` | Dependency installation |
-| Build | `pnpm turbo run build` | Compile all packages and apps |
-| Test | `pnpm turbo run test` | Run vitest suites |
+| Build | `pnpm turbo run build --filter=!identity-api...` | Compile all packages and apps except identity-api |
+| Test | `pnpm turbo run test --filter=!identity-api...` | Run vitest suites except identity-api |
 
 The reusable setup and test logic lives in `.github/tests/action.yml` (composite action) so it can be shared across workflows.
 

--- a/.github/tests/action.yml
+++ b/.github/tests/action.yml
@@ -32,8 +32,8 @@ runs:
 
     - name: Build
       shell: bash
-      run: pnpm turbo run build
+      run: pnpm turbo run build --filter=!identity-api...
 
     - name: Test
       shell: bash
-      run: pnpm turbo run test
+      run: pnpm turbo run test --filter=!identity-api...


### PR DESCRIPTION
This pull request updates the CI/CD pipeline to exclude the `identity-api` package from the build and test steps. This change is reflected both in the documentation and in the shared GitHub Actions workflow configuration.

**CI/CD pipeline updates:**

* Updated the build and test commands in `.github/cicd-plan.md` to use `pnpm turbo run build --filter=!identity-api...` and `pnpm turbo run test --filter=!identity-api...`, ensuring that all packages and apps except `identity-api` are compiled and tested.
* Modified `.github/tests/action.yml` to use the same filtered build and test commands, so that the shared CI workflow consistently skips `identity-api` during these steps.


Closes #608 