### PR TITLE
fix(nexus-web): add skeleton, standardized elements, adjust background bracket, fix pagination on mobile

### DIFF
--- a/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseAchievements.tsx
+++ b/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseAchievements.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   CardFooter,
   CardHeader,
+  Skeleton,
   Stack,
   Text,
 } from "@packages/spark-ui";
@@ -19,26 +20,74 @@ import {
   SECTION_VIEWPORT,
 } from "./memberShowcaseMotion";
 import { useMemberShowcases } from "../hooks/useMemberShowcases";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
-
-// const MEMBER_ACHIEVEMENT_CARDS = [
-//   { src: ASSETS.MEMBER_SHOWCASE.ACHIEVEMENTS.CICADA, alt: "Cicada", title: "Lorem Ipsum" },
-//   { src: ASSETS.MEMBER_SHOWCASE.ACHIEVEMENTS.OMAGAD, alt: "Omagad", title: "Lorem Ipsum" },
-//   { src: ASSETS.MEMBER_SHOWCASE.ACHIEVEMENTS.SPARKPLUG, alt: "Sparkplug", title: "Lorem Ipsum" },
-// ];
 
 const achievementsSectionVariants = createSectionVariants(
   SECTION_DELAYS.achievements,
 );
 const achievementsListVariants = createContainerVariants(0.18, 0.14);
 
+function AchievementSkeletonCard() {
+  return (
+    <Card className="relative w-full overflow-hidden bg-[#1d2231]/85 shadow-[0_7px_18px_rgba(0,0,0,0.25)] backdrop-blur-md">
+      <div className="relative z-10">
+        {/* Fixed 293×208 aspect ratio skeleton matches the image wrapper */}
+        <Skeleton
+          className="w-full rounded-lg"
+          style={{ aspectRatio: "293/208" }}
+        />
+        <div className="mt-3 px-4 md:mt-3.5">
+          <Skeleton className="h-6 w-3/4" />
+        </div>
+        <div className="mt-4 flex justify-end px-4 pb-4 md:mt-5">
+          <Skeleton className="h-10 w-10 rounded-md" />
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function AchievementsLoadingState() {
+  return (
+    <div className="grid flex-1 min-w-0 grid-cols-1 gap-4 md:grid-cols-2 md:gap-5 lg:grid-cols-3 lg:gap-6">
+      <AchievementSkeletonCard />
+      <div className="hidden md:block">
+        <AchievementSkeletonCard />
+      </div>
+      <div className="hidden lg:block">
+        <AchievementSkeletonCard />
+      </div>
+    </div>
+  );
+}
+
 export function MemberShowcaseAchievements() {
   const prefersReduced = useReducedMotion();
 
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(3);
-  const { data, error, isLoading } = useMemberShowcases(page, pageSize);
+  const [pageSize, setPageSize] = useState(3); // SSR-safe default
+  const prevPageSizeRef = useRef(3);
+
+  // Sync pageSize with the number of visible columns at each breakpoint:
+  // mobile (< 768px) = 1, tablet (< 1024px) = 2, desktop = 3
+  // Also resets page to 1 when the breakpoint is crossed to prevent skipping.
+  useEffect(() => {
+    const updatePageSize = () => {
+      const next =
+        window.innerWidth < 768 ? 1 : window.innerWidth < 1024 ? 2 : 3;
+      if (next !== prevPageSizeRef.current) {
+        prevPageSizeRef.current = next;
+        setPageSize(next);
+        setPage(1);
+      }
+    };
+    updatePageSize();
+    window.addEventListener("resize", updatePageSize);
+    return () => window.removeEventListener("resize", updatePageSize);
+  }, []);
+
+  const { data, isLoading, error } = useMemberShowcases(page, pageSize);
 
   const MEMBER_ACHIEVEMENT_CARDS = data
     ? data.data.map((showcase) => ({
@@ -48,8 +97,6 @@ export function MemberShowcaseAchievements() {
         title: showcase.title,
       }))
     : [];
-
-  console.log("Member Showcases Data:", MEMBER_ACHIEVEMENT_CARDS);
 
   const handleOnNextPage = async () => {
     setPage((prev) =>
@@ -89,78 +136,86 @@ export function MemberShowcaseAchievements() {
         >
           <motion.div variants={prefersReduced ? undefined : ITEM_VARIANTS}>
             <Button
-              className="rounded-full px-0 w-9 h-9 min-w-0 md:w-10 md:h-10 lg:w-12 lg:h-12"
+              className="rounded-full px-0 w-9 h-9 min-w-0 md:w-10 md:h-10 lg:w-12 lg:h-12 shrink-0"
               size="lg"
               subVariant="blue"
               variant="colored"
               onClick={handleOnPreviousPage}
-              disabled={page === 1}
+              disabled={page === 1 || isLoading}
             >
               ←
             </Button>
           </motion.div>
 
-          <motion.div
-            className="grid flex-1 grid-cols-1 gap-4 overflow-hidden md:grid-cols-2 md:gap-5 lg:grid-cols-3 lg:gap-6"
-            variants={prefersReduced ? undefined : achievementsListVariants}
-          >
-            {MEMBER_ACHIEVEMENT_CARDS.map((card, index) => (
-              <motion.div
-                key={`${card.alt}-${index}`}
-                className={index > 0 ? "hidden md:block" : "block"}
-                // variants={prefersReduced ? undefined : ITEM_VARIANTS}
-              >
-                <Card className="relative w-full overflow-hidden bg-[#1d2231]/85 shadow-[0_7px_18px_rgba(0,0,0,0.25)] backdrop-blur-md">
-                  <div className="pointer-events-none absolute inset-0 z-0">
-                    <div className="absolute inset-0 rounded-[inherit] bg-[linear-gradient(180deg,rgba(69,88,132,0.55)_0%,rgba(31,40,66,0.86)_38%,rgba(15,27,59,0.98)_100%)]" />
-                    <div className="absolute inset-0 rounded-[inherit] mix-blend-overlay opacity-80 blur-xl bg-[radial-gradient(130%_90%_at_50%_120%,rgba(92,132,255,0.84)_0%,rgba(68,205,255,0.4)_30%,rgba(68,205,255,0)_62%)]" />
-                    <div className="absolute right-0 bottom-5 left-0 h-24 bg-[radial-gradient(84%_185%_at_50%_100%,rgba(140,166,255,0.78)_0%,rgba(140,166,255,0.3)_48%,rgba(140,166,255,0)_78%)] blur-2xl" />
-                    <div className="absolute right-2 bottom-5 left-2 h-16 bg-[radial-gradient(95%_180%_at_50%_100%,rgba(79,255,173,0.62)_0%,rgba(79,255,173,0)_80%)] blur-xl" />
-                    <div className="absolute -top-12 -left-24 h-24 w-[170%] rotate-30 bg-[linear-gradient(90deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.62)_50%,rgba(255,255,255,0)_100%)] opacity-50 blur-[6px] mix-blend-overlay" />
-                  </div>
+          {isLoading ? (
+            <AchievementsLoadingState />
+          ) : (
+            <motion.div
+              className="grid flex-1 min-w-0 grid-cols-1 gap-4 md:grid-cols-2 md:gap-5 lg:grid-cols-3 lg:gap-6"
+              variants={prefersReduced ? undefined : achievementsListVariants}
+            >
+              {MEMBER_ACHIEVEMENT_CARDS.map((card, index) => (
+                <motion.div
+                  key={`${card.alt}-${index}`}
+                  className={index === 1 ? "hidden md:block" : index === 2 ? "hidden lg:block" : undefined}
+                >
+                  <Card className="relative w-full overflow-hidden bg-[#1d2231]/85 shadow-[0_7px_18px_rgba(0,0,0,0.25)] backdrop-blur-md">
+                    <div className="pointer-events-none absolute inset-0 z-0">
+                      <div className="absolute inset-0 rounded-[inherit] bg-[linear-gradient(180deg,rgba(69,88,132,0.55)_0%,rgba(31,40,66,0.86)_38%,rgba(15,27,59,0.98)_100%)]" />
+                      <div className="absolute inset-0 rounded-[inherit] mix-blend-overlay opacity-80 blur-xl bg-[radial-gradient(130%_90%_at_50%_120%,rgba(92,132,255,0.84)_0%,rgba(68,205,255,0.4)_30%,rgba(68,205,255,0)_62%)]" />
+                      <div className="absolute right-0 bottom-5 left-0 h-24 bg-[radial-gradient(84%_185%_at_50%_100%,rgba(140,166,255,0.78)_0%,rgba(140,166,255,0.3)_48%,rgba(140,166,255,0)_78%)] blur-2xl" />
+                      <div className="absolute right-2 bottom-5 left-2 h-16 bg-[radial-gradient(95%_180%_at_50%_100%,rgba(79,255,173,0.62)_0%,rgba(79,255,173,0)_80%)] blur-xl" />
+                      <div className="absolute -top-12 -left-24 h-24 w-[170%] rotate-30 bg-[linear-gradient(90deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.62)_50%,rgba(255,255,255,0)_100%)] opacity-50 blur-[6px] mix-blend-overlay" />
+                    </div>
 
-                  <div className="relative z-10">
-                    <Image
-                      src={card.src}
-                      alt={card.alt}
-                      width={2048}
-                      height={2048}
-                      className="h-44 w-full rounded-lg border border-white object-cover md:h-48 lg:h-52"
-                    />
-                    <CardHeader className="mt-3 text-lg font-bold md:mt-3.5 md:text-xl">
-                      {card.title}
-                    </CardHeader>
-                    <CardFooter className="mt-4 flex justify-end md:mt-5">
-                      <Link href={card.articleUrl || "#"}>
-                        <Button
-                          className="w-fit"
-                          size="lg"
-                          subVariant="blue"
-                          variant="colored"
-                        >
-                          <Image
-                            src={ASSETS.MEMBER_SHOWCASE.ICONS.LINK}
-                            alt="Link"
-                            width={27}
-                            height={27}
-                          />
-                        </Button>
-                      </Link>
-                    </CardFooter>
-                  </div>
-                </Card>
-              </motion.div>
-            ))}
-          </motion.div>
+                    <div className="relative z-10">
+                      {/* Fixed 293×208 aspect-ratio wrapper — prevents warping at any screen size */}
+                      <div
+                        className="relative w-full overflow-hidden rounded-lg border border-white"
+                        style={{ aspectRatio: "293/208" }}
+                      >
+                        <Image
+                          src={card.src}
+                          alt={card.alt}
+                          fill
+                          className="object-cover pointer-events-none"
+                        />
+                      </div>
+                      <CardHeader className="mt-3 text-lg font-bold md:mt-3.5 md:text-xl">
+                        {card.title}
+                      </CardHeader>
+                      <CardFooter className="mt-4 flex justify-end md:mt-5">
+                        <Link href={card.articleUrl || "#"}>
+                          <Button
+                            className="w-fit"
+                            size="lg"
+                            subVariant="blue"
+                            variant="colored"
+                          >
+                            <Image
+                              src={ASSETS.MEMBER_SHOWCASE.ICONS.LINK}
+                              alt="Link"
+                              width={27}
+                              height={27}
+                            />
+                          </Button>
+                        </Link>
+                      </CardFooter>
+                    </div>
+                  </Card>
+                </motion.div>
+              ))}
+            </motion.div>
+          )}
 
           <motion.div variants={prefersReduced ? undefined : ITEM_VARIANTS}>
             <Button
-              className="rounded-full px-0 w-9 h-9 min-w-0 md:w-10 md:h-10 lg:w-12 lg:h-12"
+              className="rounded-full px-0 w-9 h-9 min-w-0 md:w-10 md:h-10 lg:w-12 lg:h-12 shrink-0"
               size="lg"
               subVariant="blue"
               variant="colored"
               onClick={handleOnNextPage}
-              disabled={page === (data ? data.meta.totalPages : 1)}
+              disabled={page === (data ? data.meta.totalPages : 1) || isLoading}
             >
               →
             </Button>

--- a/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseBackground.tsx
+++ b/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseBackground.tsx
@@ -136,11 +136,10 @@ export function MemberShowcaseBackground({
       <Image
         src={ASSETS.MEMBER_SHOWCASE.BACKGROUND.GDG_SHADOW}
         alt="gdg shadow"
-        className="z-3 pointer-events-none absolute -bottom-50 -right-15 h-auto w-auto max-w-none"
+        className="z-3 pointer-events-none absolute -bottom-50 -right-15 w-126.5 h-auto"
         width={506}
         height={507}
-      >
-      </Image>
+      />
       <Image
         src={ASSETS.MEMBER_SHOWCASE.BACKGROUND.VECTOR_1296}
         alt="vector decoration left"

--- a/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseSpotlight.tsx
+++ b/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseSpotlight.tsx
@@ -4,20 +4,9 @@ import Image from "next/image";
 import { motion, useReducedMotion } from "motion/react";
 import { Button, Inline, Skeleton, Stack, Text } from "@packages/spark-ui";
 import { ASSETS } from "@/lib/constants/assets";
-import {
-  createContainerVariants,
-  createSectionVariants,
-  ITEM_VARIANTS,
-  SECTION_DELAYS,
-  SECTION_VIEWPORT,
-} from "./memberShowcaseMotion";
+import { ITEM_VARIANTS } from "./memberShowcaseMotion";
 import { useSpotlight } from "../hooks/useSpotlight";
 import Link from "next/link";
-
-const spotlightSectionVariants = createSectionVariants(
-  SECTION_DELAYS.spotlight,
-);
-const spotlightContainerVariants = createContainerVariants(0.16, 0.16);
 
 function SpotlightSkeleton() {
   return (
@@ -47,15 +36,9 @@ export function MemberShowcaseSpotlight() {
   const { data, isLoading, error} = useSpotlight();
 
   return (
-    <motion.div
-      variants={prefersReduced ? undefined : spotlightSectionVariants}
-      initial={prefersReduced ? undefined : "hidden"}
-      whileInView={prefersReduced ? undefined : "visible"}
-      viewport={SECTION_VIEWPORT}
-    >
-      <Stack 
-      >
-        <motion.div variants={prefersReduced ? undefined : ITEM_VARIANTS}>
+    <div>
+      <Stack>
+        <div>
           <Text
             variant="heading-4"
             gradient="white-blue"
@@ -65,14 +48,15 @@ export function MemberShowcaseSpotlight() {
           >
             Spotlight of the Day
           </Text>
-        </motion.div>
+        </div>
 
         {isLoading ? (
           <SpotlightSkeleton />
         ) : (
           <motion.div
             className="flex flex-col items-center gap-8 px-0 md:gap-10 md:px-6 lg:flex-row lg:gap-12 lg:px-24"
-            variants={prefersReduced ? undefined : spotlightContainerVariants}
+            initial={prefersReduced ? undefined : "hidden"}
+            animate={prefersReduced ? undefined : "visible"}
           >
             <motion.div
               className="relative w-full shrink-0 lg:w-120"
@@ -151,6 +135,6 @@ export function MemberShowcaseSpotlight() {
           </motion.div>
         )}
       </Stack>
-    </motion.div>
+    </div>
   );
 }

--- a/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseSpotlight.tsx
+++ b/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseSpotlight.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { motion, useReducedMotion } from "motion/react";
-import { Button, Inline, Stack, Text } from "@packages/spark-ui";
+import { Button, Inline, Skeleton, Stack, Text } from "@packages/spark-ui";
 import { ASSETS } from "@/lib/constants/assets";
 import {
   createContainerVariants,
@@ -19,10 +19,32 @@ const spotlightSectionVariants = createSectionVariants(
 );
 const spotlightContainerVariants = createContainerVariants(0.16, 0.16);
 
+function SpotlightSkeleton() {
+  return (
+    <div className="flex flex-col items-center gap-8 px-0 md:gap-10 md:px-6 lg:flex-row lg:gap-12 lg:px-24">
+      {/* Image skeleton with Sparky overlaid */}
+      <div className="relative w-full shrink-0 lg:w-120">
+        <Skeleton className="w-full rounded-2xl" style={{ aspectRatio: "640/390" }} />
+      </div>
+      {/* Text skeleton */}
+      <div className="flex-1 w-full">
+        <Stack gap="md">
+          <Skeleton className="h-8 w-3/4" />
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-4/6" />
+          <Skeleton className="h-10 w-32 mt-2" />
+        </Stack>
+      </div>
+    </div>
+  );
+}
+
 export function MemberShowcaseSpotlight() {
   const prefersReduced = useReducedMotion();
 
-  const { data, error, isLoading } = useSpotlight();
+  const { data, isLoading, error} = useSpotlight();
 
   return (
     <motion.div
@@ -31,96 +53,103 @@ export function MemberShowcaseSpotlight() {
       whileInView={prefersReduced ? undefined : "visible"}
       viewport={SECTION_VIEWPORT}
     >
-      <Stack>
+      <Stack 
+      >
         <motion.div variants={prefersReduced ? undefined : ITEM_VARIANTS}>
           <Text
             variant="heading-4"
             gradient="white-blue"
             weight="bold"
             align="center"
+            className="text-xl font-bold w-auto pl-16"
           >
             Spotlight of the Day
           </Text>
         </motion.div>
 
-        <motion.div
-          className="mt-8 flex flex-col items-center gap-8 px-0 md:mt-10 md:gap-10 md:px-6 lg:mt-12 lg:flex-row lg:gap-12 lg:px-24"
-          variants={prefersReduced ? undefined : spotlightContainerVariants}
-        >
+        {isLoading ? (
+          <SpotlightSkeleton />
+        ) : (
           <motion.div
-            className="relative w-full shrink-0 lg:w-120"
-            variants={prefersReduced ? undefined : ITEM_VARIANTS}
-            whileHover={prefersReduced ? undefined : { rotate: -2, y: -4 }}
-            transition={
-              prefersReduced
-                ? undefined
-                : { type: "spring", stiffness: 220, damping: 18 }
-            }
+            className="flex flex-col items-center gap-8 px-0 md:gap-10 md:px-6 lg:flex-row lg:gap-12 lg:px-24"
+            variants={prefersReduced ? undefined : spotlightContainerVariants}
           >
-            <Image
-              src={data ? data.data.thumbnailUrl : ASSETS.PLACEHOLDERS.DEFAULT}
-              alt="Spotlight featured image"
-              width={480}
-              height={340}
-              className="w-full rounded-2xl object-cover pointer-events-none"
-            />
             <motion.div
-              whileHover={prefersReduced ? undefined : { rotate: 4, y: -6 }}
+              className="relative w-full shrink-0 lg:w-120"
+              variants={prefersReduced ? undefined : ITEM_VARIANTS}
+              whileHover={prefersReduced ? undefined : { rotate: -2, y: -4 }}
               transition={
                 prefersReduced
                   ? undefined
-                  : { type: "spring", stiffness: 240, damping: 18 }
+                  : { type: "spring", stiffness: 220, damping: 18 }
               }
             >
-              <Image
-                src={ASSETS.MEMBER_SHOWCASE.ICONS.SPARKY_LEADERBOARD}
-                alt="Sparky leaderboard"
-                width={178}
-                height={241}
-                className="pointer-events-none absolute -top-16 right-[75%] z-10 w-20 md:-top-24 md:right-[30%] md:w-24 lg:top-[-52%] lg:w-auto"
-              />
+              <div className="relative w-full overflow-hidden rounded-2xl" style={{ aspectRatio: "640/390" }}>
+                <Image
+                  src={data ? data.data.thumbnailUrl : ASSETS.PLACEHOLDERS.DEFAULT}
+                  alt="Spotlight featured image"
+                  fill
+                  className="object-cover pointer-events-none"
+                />
+              </div>
+              <motion.div
+                whileHover={prefersReduced ? undefined : { rotate: 4, y: -6 }}
+                transition={
+                  prefersReduced
+                    ? undefined
+                    : { type: "spring", stiffness: 240, damping: 18 }
+                }
+              >
+                <Image
+                  src={ASSETS.MEMBER_SHOWCASE.ICONS.SPARKY_LEADERBOARD}
+                  alt="Sparky leaderboard"
+                  width={178}
+                  height={241}
+                  className="pointer-events-none absolute z-10 w-20 h-auto -top-18.25 left-10 md:w-34 md:-top-31 lg:-top-40 lg:left-35 lg:w-44 lg:h-auto"
+                />
+              </motion.div>
+            </motion.div>
+
+            <motion.div
+              className="flex-1"
+              variants={prefersReduced ? undefined : ITEM_VARIANTS}
+            >
+              <Stack gap="md" className="text-center lg:text-left">
+                <Inline justify="between">
+                  <Text variant="heading-6" gradient="white-yellow" weight="bold">
+                    {data ? data.data.title : ""}
+                  </Text>
+                  <Button
+                    className="w-fit lg:hidden"
+                    size="md"
+                    subVariant="blue"
+                    variant="colored"
+                  >
+                    <Image
+                      src={ASSETS.MEMBER_SHOWCASE.ICONS.LINK}
+                      alt="Link"
+                      width={27}
+                      height={27}
+                    />
+                  </Button>
+                </Inline>
+                <Text variant="body" color="secondary">
+                  {data ? data.data.createdAt : ""}
+                </Text>
+                <Text variant="body" color="on-primary">
+                  {data ? data.data.description : ""}
+                </Text>
+                <div className="justify-center hidden lg:flex lg:justify-start">
+                  <Link href={data ? data.data.articleUrl : "#"}>
+                    <Button variant="colored" subVariant="blue" size="lg">
+                      Learn more
+                    </Button>
+                  </Link>
+                </div>
+              </Stack>
             </motion.div>
           </motion.div>
-
-          <motion.div
-            className="flex-1"
-            variants={prefersReduced ? undefined : ITEM_VARIANTS}
-          >
-            <Stack gap="md" className="text-center lg:text-left">
-              <Inline justify="between">
-                <Text variant="heading-6" gradient="white-yellow" weight="bold">
-                  {data ? data.data.title : "Loading..."}
-                </Text>
-                <Button
-                  className="w-fit lg:hidden"
-                  size="md"
-                  subVariant="blue"
-                  variant="colored"
-                >
-                  <Image
-                    src={ASSETS.MEMBER_SHOWCASE.ICONS.LINK}
-                    alt="Link"
-                    width={27}
-                    height={27}
-                  />
-                </Button>
-              </Inline>
-              <Text variant="body" color="secondary">
-                {data ? data.data.createdAt : "Loading description..."}
-              </Text>
-              <Text variant="body" color="on-primary">
-                {data ? data.data.description : "Loading description..."}
-              </Text>
-              <div className="justify-center hidden lg:flex lg:justify-start">
-                <Link href={data ? data.data.articleUrl : "#"}>
-                  <Button variant="colored" subVariant="blue" size="lg">
-                    Learn more
-                  </Button>
-                </Link>
-              </div>
-            </Stack>
-          </motion.div>
-        </motion.div>
+        )}
       </Stack>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
This PR enhances the Member Showcase features by introducing skeleton loading states, improving responsive design, and refining image presentation. Previously, the Achievements and Spotlight sections lacked visual feedback during data fetching, navigation was active during loading, and image layouts were inconsistent across breakpoints.

## Strategies
- Added skeleton loading components (`AchievementSkeletonCard`, `AchievementsLoadingState`, and `SpotlightSkeleton`) to display placeholders while data loads, improving perceived performance
- Dynamically adjusted visible achievement cards (`pageSize`) based on screen width using a `useEffect` hook, with pagination resetting at mobile, tablet, and desktop breakpoints
- Standardized image aspect ratios and container wrappers across both sections to prevent warping and maintain visual consistency
- Disabled navigation buttons during loading to prevent inconsistent state or errors
- Replaced temporary loading text in Spotlight details with empty strings, since skeleton components now handle the loading indication
- Adjusted decorative image placement and sizing for improved alignment across breakpoints

## Additional Information
- No existing functionality was removed; all changes are additive or refinements
- Skeleton components are scoped to the Achievements and Spotlight sections only
- Responsive breakpoints align with the existing design system grid