### PR TITLE
chore: add ComingSoonPlaceholder component and integrate into sparkmate sections

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/ComingSoonPlaceholder.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/ComingSoonPlaceholder.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image";
+import { Text } from "@packages/spark-ui";
+import { ASSETS } from "@/lib/constants/assets";
+
+export function ComingSoonPlaceholder() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 rounded-2xl">
+      <div className="relative h-60 w-60 drop-shadow-[0_0_20px_rgba(43,127,255,0.4)]">
+        <Image
+          src={ASSETS.SPARKY_POINTS.CIRBY_DENIED}
+          alt="Coming Soon"
+          fill
+          className="object-contain"
+        />
+      </div>
+      <Text variant="body" className="mt-4 text-[#C1C7CD]" weight="medium">
+        Coming Soon!
+      </Text>
+    </div>
+  );
+}

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
@@ -140,11 +140,11 @@ export function ProfileOwnerView({
 
               <Divider />
 
-              {/* {userprofile && <ImpactSection profile={userprofile} />} */}
+              {userprofile && <ImpactSection profile={userprofile} />}
 
-              {/* <Divider /> */}
+              <Divider />
 
-              {/* {userprofile && <BadgesSection profile={userprofile} />} */}
+              {userprofile && <BadgesSection profile={userprofile} />}
             </div>
           </FadeInSection>
 

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/BadgesSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/BadgesSection.tsx
@@ -3,26 +3,25 @@ import React from "react";
 import { viewIcon } from "../icons/viewIcon"; 
 import { UserProfile } from "@/features/sparkmates";
 import { ASSETS } from "@/lib/constants/assets";
+import { ComingSoonPlaceholder } from "../../ComingSoonPlaceholder";
 
 export const BadgesSection = ({ profile }: { profile: UserProfile }) => {
-  const badgeCards = [1, 2, 3];
-
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
         <Text variant="heading-6" gradient="white-blue" weight="bold">
           Badges
         </Text>
-        <Button
+        {/* <Button
           variant="default"
           size="sm"
           className="text-white"
           iconRight={viewIcon}
         >
           View All
-        </Button>
+        </Button> */}
       </div>
-      <Text variant="body-sm" className="text-[#C1C7CD]">
+      {/* <Text variant="body-sm" className="text-[#C1C7CD]">
         Unlock exclusive collectibles by attending events.
       </Text>
       <div className="grid grid-cols-3 gap-4">
@@ -41,7 +40,8 @@ export const BadgesSection = ({ profile }: { profile: UserProfile }) => {
             </Text>
           </div>
         ))}
-      </div>
+      </div> */}
+      <ComingSoonPlaceholder />
     </section>
   );
 };

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/ImpactSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/ImpactSection.tsx
@@ -2,6 +2,7 @@ import { Button, Text } from "@packages/spark-ui";
 import React from "react";
 import { viewIcon } from "../icons/viewIcon";
 import { UserProfile } from "@/features/sparkmates";
+import { ComingSoonPlaceholder } from "../../ComingSoonPlaceholder";
 
 export const ImpactSection = ({ profile }: { profile: UserProfile }) => {
   return (
@@ -10,16 +11,16 @@ export const ImpactSection = ({ profile }: { profile: UserProfile }) => {
         <Text variant="heading-6" gradient="white-blue" weight="bold">
           GDG Impact
         </Text>
-        <Button
+        {/* <Button
           variant="default"
           size="sm"
           className="text-white"
           iconRight={viewIcon}
         >
           View
-        </Button>
+        </Button> */}
       </div>
-      <Text variant="body-sm" className="text-[#C1C7CD]">
+      {/* <Text variant="body-sm" className="text-[#C1C7CD]">
         Track your milestones and growth within GDG.
       </Text>
       <div className="grid grid-cols-3 gap-4">
@@ -41,7 +42,8 @@ export const ImpactSection = ({ profile }: { profile: UserProfile }) => {
             </Text>
           </div>
         ))}
-      </div>
+      </div> */}
+      <ComingSoonPlaceholder />
     </section>
   );
 };

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
@@ -15,6 +15,7 @@ import { CosmosParticles } from "@/components/shared";
 import { ASSETS } from "@/lib/constants/assets";
 import { SparkmatesSource, useSparkmateProfile, useSuggestedSparkmates } from "../.."; 
 import { PublicSkillsAndLinksSection } from "./components/PublicSkillsAndLinksSection";
+import { ComingSoonPlaceholder } from "../ComingSoonPlaceholder";
 
 const viewIcon = (
   <svg
@@ -616,7 +617,7 @@ export function ProfilePublicView({
                     View
                   </Button>
                 </div>
-                <Text variant="body-sm" className="text-[#C1C7CD]">
+                {/* <Text variant="body-sm" className="text-[#C1C7CD]">
                   Track your milestones and growth within GDG.
                 </Text>
                 <div className="grid grid-cols-3 gap-4">
@@ -642,7 +643,8 @@ export function ProfilePublicView({
                       </Text>
                     </div>
                   ))}
-                </div>
+                </div> */}
+                <ComingSoonPlaceholder /> 
               </section>
 
               <Divider />
@@ -661,7 +663,7 @@ export function ProfilePublicView({
                     View All
                   </Button>
                 </div>
-                <Text variant="body-sm" className="text-[#C1C7CD]">
+                {/* <Text variant="body-sm" className="text-[#C1C7CD]">
                   Unlock exclusive collectibles by attending events.
                 </Text>
                 <div className="grid grid-cols-3 gap-4">
@@ -684,7 +686,8 @@ export function ProfilePublicView({
                       </Text>
                     </div>
                   ))}
-                </div>
+                </div> */}
+                <ComingSoonPlaceholder />
               </section>
             </div>
           </FadeInSection>

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
@@ -608,14 +608,14 @@ export function ProfilePublicView({
                   <Text variant="heading-6" gradient="white-blue" weight="bold">
                     GDG Impact
                   </Text>
-                  <Button
+                  {/* <Button
                     variant="default"
                     size="sm"
                     className="text-white"
                     iconRight={viewIcon}
                   >
                     View
-                  </Button>
+                  </Button> */}
                 </div>
                 {/* <Text variant="body-sm" className="text-[#C1C7CD]">
                   Track your milestones and growth within GDG.
@@ -654,14 +654,14 @@ export function ProfilePublicView({
                   <Text variant="heading-6" gradient="white-blue" weight="bold">
                     Badges
                   </Text>
-                  <Button
+                  {/* <Button
                     variant="default"
                     size="sm"
                     className="text-white"
                     iconRight={viewIcon}
                   >
                     View All
-                  </Button>
+                  </Button> */}
                 </div>
                 {/* <Text variant="body-sm" className="text-[#C1C7CD]">
                   Unlock exclusive collectibles by attending events.


### PR DESCRIPTION
Closes #701 
<img width="1832" height="913" alt="image" src="https://github.com/user-attachments/assets/5741a09e-550a-49e8-b7c6-30e662cb6895" />

This pull request introduces a new `ComingSoonPlaceholder` component and uses it to replace the content of the "Impact" and "Badges" sections in both the owner and public Sparkmates profile views. The previous content and related UI elements for these sections have been commented out, indicating these features are not yet available and will be coming soon.

**Component introduction and usage:**

* Added a reusable `ComingSoonPlaceholder` component that displays a "Coming Soon!" message with an image (`ComingSoonPlaceholder.tsx`).

**Profile section updates:**

* Updated the "Impact" and "Badges" sections in both the owner (`ProfileOwnerView.tsx`, `ImpactSection.tsx`, `BadgesSection.tsx`) and public (`ProfilePublicView.tsx`) profile views to display the `ComingSoonPlaceholder` instead of their previous content. [[1]](diffhunk://#diff-aa53237aa92fddf5fae8a1ee8e29ef003f35123d1971a29d808e9a4bf7c18926R5) [[2]](diffhunk://#diff-aa53237aa92fddf5fae8a1ee8e29ef003f35123d1971a29d808e9a4bf7c18926L13-R23) [[3]](diffhunk://#diff-aa53237aa92fddf5fae8a1ee8e29ef003f35123d1971a29d808e9a4bf7c18926L44-R46) [[4]](diffhunk://#diff-f993b727317500ffef3af332c4a3f381cd02dc0990d88f213213e47c67a10171R6-R24) [[5]](diffhunk://#diff-f993b727317500ffef3af332c4a3f381cd02dc0990d88f213213e47c67a10171L44-R44) [[6]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R18) [[7]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L610-R620) [[8]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L645-R647) [[9]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L655-R666) [[10]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L687-R690)

**Code cleanup:**

* Commented out the old UI elements and content (buttons, descriptions, and badge/impact lists) in the affected sections, preserving the structure for future implementation. [[1]](diffhunk://#diff-aa53237aa92fddf5fae8a1ee8e29ef003f35123d1971a29d808e9a4bf7c18926L13-R23) [[2]](diffhunk://#diff-aa53237aa92fddf5fae8a1ee8e29ef003f35123d1971a29d808e9a4bf7c18926L44-R46) [[3]](diffhunk://#diff-f993b727317500ffef3af332c4a3f381cd02dc0990d88f213213e47c67a10171R6-R24) [[4]](diffhunk://#diff-f993b727317500ffef3af332c4a3f381cd02dc0990d88f213213e47c67a10171L44-R44) [[5]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L610-R620) [[6]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L645-R647) [[7]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L655-R666) [[8]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L687-R690)

**Section visibility:**

* Ensured both "Impact" and "Badges" sections are now always visible in the owner view, even though their content is replaced with the placeholder.