### PR TITLE
feat(nexus-web): add and integrate mini preview card component

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
@@ -1,10 +1,11 @@
 "use client";
  
-import { Badge, Button, Input, ShineBorder, Text } from "@packages/spark-ui";
+import { Button, Modal, ShineBorder, Text } from "@packages/spark-ui";
 import { CosmosParticles, LoadingScreen } from "@/components/shared";
-import { ASSETS } from "@/lib/constants/assets";
 import Link from "next/link";
-import { useSparkmateProfile, useSuggestedSparkmates } from "../../hooks";
+import { useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
+import { useSparkmateProfile } from "../../hooks";
 import { SparkmatesSource } from "../../types";
 import { SkillsAndLinksSection } from "./sections/SkillsAndLinksSection"; 
 import { viewIcon } from "./icons/viewIcon"; 
@@ -13,11 +14,11 @@ import { Divider } from "./components/Divider";
 import { FadeInSection } from "./components/FadeInSection";
 import { NameAndProfileSection } from "./sections/NameAndProfileSection";
 import { useGetProfileOfUserByGdgId } from "../../hooks/useGetProfileOfUserByGdgId";
-import { CustomButtonsSection } from "./sections/CustomButtonsSection";
 import { BadgesSection } from "./sections/BadgesSection";
 import { ProjectsSection } from "./sections/ProjectsSection";
 import { ImpactSection } from "./sections/ImpactSection";
 import { SuggestedPeopleSection } from "./sections/SuggestedPeopleSection";
+import { SparkmatesMiniPreviewCard } from "./components/SparkmatesMiniPreviewCard";
  
 export function ProfileOwnerView({
   gdgId,
@@ -26,6 +27,38 @@ export function ProfileOwnerView({
   gdgId: string;
   source: SparkmatesSource;
 }) {
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [isPreviewClosing, setIsPreviewClosing] = useState(false);
+  const [previewTilt, setPreviewTilt] = useState({ rotateX: 0, rotateY: 0 });
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, []);
+
+  const requestClosePreview = () => {
+    setIsPreviewClosing(true);
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+    }
+    closeTimerRef.current = setTimeout(() => {
+      setIsPreviewOpen(false);
+      setIsPreviewClosing(false);
+    }, 220);
+  };
+
+  const handlePreviewOpenChange = (open: boolean) => {
+    if (open) {
+      setIsPreviewClosing(false);
+      setIsPreviewOpen(true);
+      return;
+    }
+    requestClosePreview();
+  };
 
   const {
     data: profile,
@@ -36,11 +69,8 @@ export function ProfileOwnerView({
 
   const {
     data: userprofiledata,
-    error: usererror,
-    isLoading: userisLoading,
   } = useGetProfileOfUserByGdgId(gdgId);
   const userprofile = userprofiledata?.data;
-  console.log("User Profile:", userprofile);
 
 
   if (isLoading) {
@@ -126,6 +156,11 @@ export function ProfileOwnerView({
                   size="sm"
                   iconRight={viewIcon}
                   className="px-3 py-1 text-white"
+                  onClick={() => {
+                    setIsPreviewClosing(false);
+                    setIsPreviewOpen(true);
+                  }}
+                  disabled={!userprofile}
                 >
                   Preview
                 </Button>
@@ -157,6 +192,58 @@ export function ProfileOwnerView({
 
           {userprofile && <SuggestedPeopleSection profile={userprofile} />}
         </div>
+
+        <Modal
+          open={isPreviewOpen}
+          onOpenChange={handlePreviewOpenChange}
+          size="sm"
+          scrollBehavior="outside"
+          placement="center"
+          closeOnEsc={false}
+          className="bg-transparent border-none p-0 !shadow-none isolate w-full max-w-[410px]"
+        >
+          <div className="flex min-h-[calc(100dvh-1.5rem)] items-center justify-center px-3 py-2 sm:min-h-0 sm:px-4 sm:py-3">
+            <div
+              className="group relative"
+              style={{ perspective: "1200px" }}
+              onMouseMove={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect();
+                const x = (event.clientX - rect.left) / rect.width;
+                const y = (event.clientY - rect.top) / rect.height;
+                const rotateY = (x - 0.5) * 10;
+                const rotateX = (0.5 - y) * 10;
+                setPreviewTilt({ rotateX, rotateY });
+              }}
+              onMouseLeave={() => setPreviewTilt({ rotateX: 0, rotateY: 0 })}
+            >
+              <motion.div
+                initial={{ opacity: 0, scale: 0.84, y: 16 }}
+                animate={
+                  isPreviewClosing
+                    ? { opacity: 0, scale: 0.9, y: 10 }
+                    : { opacity: 1, scale: 1, y: 0 }
+                }
+                transition={{ duration: 0.22, ease: "easeOut" }}
+              >
+                <div
+                className="relative overflow-hidden rounded-[1.75rem] border border-white/20 bg-[linear-gradient(165deg,rgba(16,23,47,0.96),rgba(6,12,32,0.98))] p-2 shadow-[0_20px_55px_rgba(0,0,0,0.65)] transition-transform duration-200 ease-out"
+                style={{
+                  transform: `rotateX(${previewTilt.rotateX}deg) rotateY(${previewTilt.rotateY}deg)`,
+                  transformStyle: "preserve-3d",
+                }}
+              >
+                <ShineBorder
+                  borderWidth={2}
+                  duration={8}
+                  shineColor={["#EA4335", "#F9AB00", "#34A853", "#4285F4"]}
+                  style={{ borderRadius: 28 }}
+                />
+                {userprofile ? <SparkmatesMiniPreviewCard profile={userprofile} /> : null}
+              </div>
+              </motion.div>
+            </div>
+          </div>
+        </Modal>
       </div>
     </CosmosParticles>
   );

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/SparkmatesMiniPreviewCard.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/SparkmatesMiniPreviewCard.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import Image from "next/image";
+import { Badge, Button, Text } from "@packages/spark-ui";
+import { ASSETS } from "@/lib/constants/assets";
+import { UserProfile } from "@/features/sparkmates";
+import { GradientProfilePicture } from "./GradientProfilePicture";
+
+function openExternal(url: string) {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+export function SparkmatesMiniPreviewCard({ profile }: { profile: UserProfile }) {
+  const fullName =
+    [profile?.firstName, profile?.middleName, profile?.lastName, profile?.suffix]
+      .filter(Boolean)
+      .join(" ") || "Your Name";
+
+  const topBadges = [profile.department, profile.technicalSkills?.[0]]
+    .filter((value): value is string => Boolean(value))
+    .slice(0, 2);
+
+  const technicalSkills = profile.technicalSkills ?? [];
+  const learningInterests = profile.learningInterests ?? [];
+
+  return (
+    <div className="relative h-[min(90dvh,860px)] overflow-y-auto sm:overflow-hidden rounded-3xl border border-white/20 bg-[#010B1D] text-white shadow-[0_22px_48px_rgba(0,0,0,0.52),inset_0px_4px_16px_rgba(255,255,255,0.1)] [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+      <div className="absolute inset-x-0 top-0 h-56 pointer-events-none">
+        <Image
+          src={ASSETS.SPARKMATES.HORIZON}
+          alt=""
+          aria-hidden
+          fill
+          className="object-cover"
+          style={{ objectPosition: "50% 65%" }}
+          priority
+        />
+        <div className="absolute inset-x-0 top-0 h-1/2 bg-gradient-to-b from-[#010B1D] to-transparent" />
+        <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-[#010B1D] to-transparent" />
+      </div>
+
+      <div className="relative z-10 flex h-full flex-col px-5 pb-4 pt-7">
+        <div className="flex justify-center">
+          <GradientProfilePicture
+            size="sm"
+            src={profile.avatarUrl || ASSETS.PROFILE.DEFAULT_AVATAR}
+            alt={profile.displayName || fullName}
+            fallback={(profile.displayName || fullName).charAt(0)}
+          />
+        </div>
+
+        <div className="mt-2.5 text-center">
+          <Text variant="heading-6" weight="bold" align="center" className="text-center text-white leading-tight">
+            {fullName}
+          </Text>
+
+          {profile.displayName ? (
+            <Text variant="body-sm" align="center" className="mt-0.5 text-center text-zinc-400">
+              ({profile.displayName})
+            </Text>
+          ) : null}
+
+          <Text variant="body-sm" align="center" className="mt-1 text-center text-[#C1C7CD]">
+            {profile.program || "Program & Year not set"}
+          </Text>
+
+          <div className="mt-2.5 flex flex-wrap justify-center gap-2">
+            {topBadges.map((badge) => (
+              <Badge key={badge} variant="yellow">
+                {badge}
+              </Badge>
+            ))}
+            <Badge variant="id">{profile.gdgId}</Badge>
+          </div>
+
+          <Text variant="body-sm" align="center" className="mt-2.5 text-center text-[#E5E5E5] leading-relaxed line-clamp-3">
+            {profile.bio || "Share your story to let sparkmates know what you are building."}
+          </Text>
+
+          <div className="mt-5 space-y-2.5">
+            <Button
+              variant="default"
+              size="sm"
+              disabled={!profile.portfolioWebsiteUrl}
+              className="h-11 w-full text-white disabled:opacity-40"
+              onClick={() => {
+                if (!profile.portfolioWebsiteUrl) return;
+                openExternal(profile.portfolioWebsiteUrl);
+              }}
+            >
+              Visit my website
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!profile.linkedinUrl}
+              className="h-11 w-full border-white/30 bg-white/[0.03] text-white hover:bg-white/[0.08] disabled:opacity-40"
+              onClick={() => {
+                if (!profile.linkedinUrl) return;
+                openExternal(profile.linkedinUrl);
+              }}
+            >
+              LinkedIn
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!profile.githubUrl}
+              className="h-11 w-full border-white/30 bg-white/[0.03] text-white hover:bg-white/[0.08] disabled:opacity-40"
+              onClick={() => {
+                if (!profile.githubUrl) return;
+                openExternal(profile.githubUrl);
+              }}
+            >
+              GitHub
+            </Button>
+          </div>
+
+          <section className="mt-5 space-y-3">
+            <Text variant="heading-6" gradient="white-blue" weight="bold" className="text-left">
+              Skills & Interests
+            </Text>
+
+            <div className="rounded-2xl border border-white/15 bg-[rgba(255,255,255,0.06)] px-4 py-3.5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.18)]">
+              <div className="mb-2.5 flex items-center gap-2.5">
+                <svg viewBox="0 0 24 24" className="h-4.5 w-4.5 text-white" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="m8 7-5 5 5 5M16 7l5 5-5 5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <Text variant="body" weight="medium" className="text-white">
+                  Technical Skills
+                </Text>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {technicalSkills.length > 0 ? (
+                  technicalSkills.map((skill) => (
+                    <Badge key={`technical-${skill}`} variant="blue" className="text-[#F2F4F8]">
+                      {skill}
+                    </Badge>
+                  ))
+                ) : (
+                  <Text variant="body-sm" className="text-[#C1C7CD]">
+                    No technical skills yet.
+                  </Text>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/15 bg-[rgba(255,255,255,0.06)] px-4 py-3.5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.18)]">
+              <div className="mb-2.5 flex items-center gap-2.5">
+                <svg viewBox="0 0 24 24" className="h-4.5 w-4.5 text-white" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M4 5.5h8v14H4zM12 4l8-1v16l-8 1" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <Text variant="body" weight="medium" className="text-white">
+                  Learning Interests
+                </Text>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {learningInterests.length > 0 ? (
+                  learningInterests.map((interest) => (
+                    <Badge key={`interest-${interest}`} variant="blue" className="text-[#F2F4F8]">
+                      {interest}
+                    </Badge>
+                  ))
+                ) : (
+                  <Text variant="body-sm" className="text-[#C1C7CD]">
+                    No learning interests yet.
+                  </Text>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request adds a new "Mini Preview" modal for user profiles in the Sparkmates Owner View, allowing users to see a compact, interactive preview of their profile with a 3D tilt effect. The modal is triggered by a new "Preview" button and displays key profile information using a newly created `SparkmatesMiniPreviewCard` component.

**Feature: Profile Mini Preview Modal**
* Added state management and event handlers in `ProfileOwnerView.tsx` to control the opening, closing (with animation), and 3D tilt effect of the profile preview modal. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR30-R61) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR195-R246)
* Introduced a "Preview" button that opens the modal, disabled when profile data is unavailable.
* Integrated the new modal into the component tree, using the `Modal` and `motion` components for animation and presentation.

**Component: Mini Preview Card**
* Created `SparkmatesMiniPreviewCard.tsx`, a new component that displays a concise user profile with avatar, name, badges, bio, website/LinkedIn/GitHub buttons, and lists of technical skills and learning interests.
* Added 3D tilt interaction on mouse movement for the preview card, enhancing the user experience.

**Refactoring and Cleanup**
* Removed unused imports and code related to suggested sparkmates and custom buttons to streamline the file. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL3-R8) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL16-R21) [[3]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL39-L43)
* Imported and used the new `SparkmatesMiniPreviewCard` in the owner view. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL16-R21) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR195-R246)