### PR TITLE
refactor(nexus-web): improve sparkmates public-side layout and responsiveness

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
@@ -19,6 +19,7 @@ import { ProjectsSection } from "./sections/ProjectsSection";
 import { ImpactSection } from "./sections/ImpactSection";
 import { SuggestedPeopleSection } from "./sections/SuggestedPeopleSection";
 import { SparkmatesMiniPreviewCard } from "./components/SparkmatesMiniPreviewCard";
+import { CustomButtonsSection } from "./sections/CustomButtonsSection";
  
 export function ProfileOwnerView({
   gdgId,
@@ -127,9 +128,9 @@ export function ProfileOwnerView({
       moveParticlesOnHover
       alphaParticles={true}
       disableRotation={false}
-      className="min-h-screen bg-[#010B1D] bg-[radial-gradient(circle_at_30%_55%,rgba(66,133,244,0.2),transparent_30%),radial-gradient(circle_at_58%_73%,rgba(249,171,0,0.14),transparent_25%)] px-3 sm:px-6 pb-24 pt-24 sm:pt-36 text-white"
+      className="min-h-screen overflow-x-hidden bg-[#010B1D] bg-[radial-gradient(circle_at_30%_55%,rgba(66,133,244,0.2),transparent_30%),radial-gradient(circle_at_58%_73%,rgba(249,171,0,0.14),transparent_25%)] px-3 sm:px-6 pb-24 pt-24 sm:pt-36 text-white"
     >
-      <div className="relative min-h-screen w-full">
+      <div className="relative w-full">
         {/* RAINBOW ON THE BACKGROUND — desktop only */}
         <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden hidden sm:block">
           <SparkmatesRainbowStreak />
@@ -171,7 +172,7 @@ export function ProfileOwnerView({
 
             <div className="mt-6 space-y-6">
 
-              {/* {userprofile && <CustomButtonsSection profile={userprofile} />} */}
+              {userprofile && <CustomButtonsSection profile={userprofile} />}
               <Divider />
 
               {userprofile && <SkillsAndLinksSection profile={userprofile} />}

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/CustomButtonsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/CustomButtonsSection.tsx
@@ -92,23 +92,23 @@ export const CustomButtonsSection = ({ profile }: { profile: UserProfile }) => {
                     : "opacity-0 transition-opacity duration-300"
                 }
               />
-              <div className="flex items-start justify-between">
-                <div>
+              <div className="flex items-start justify-between min-w-0">
+                <div className="min-w-0 flex-1">
                   <Text
                     variant="body-lg"
-                    className="text-white"
+                    className="text-white truncate block"
                     weight="medium"
                   >
                     {item.title}
                   </Text>
-                  <Text variant="body" className="text-[#E5E5E5]">
+                  <Text variant="body" className="text-[#E5E5E5] break-all block pr-4">
                     {item.url}
                   </Text>
                 </div>
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-8 w-8 p-0 text-white"
+                  className="h-8 w-8 p-0 text-white shrink-0"
                   onClick={() => toggleStar(index)}
                 >
                   {starredCustomButtons.has(index) ? "★" : "☆"}

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/NameAndProfileSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/NameAndProfileSection.tsx
@@ -122,10 +122,9 @@ export const NameAndProfileSection = ({
       <div className="sm:hidden relative">
 
         {/* Horizon — absolute, full-viewport-width, sits BEHIND the avatar (z-0) */}
-        {/* left/right: -12px breaks out of the parent's px-3 (12px) padding */}
+        {/* -left-3 and -right-3 breaks out of the parent's px-3 (12px) padding */}
         <div
-          className="absolute z-0 pointer-events-none overflow-hidden"
-          style={{ left: "-12px", right: "-12px", top: 0, height: "220px" }}
+          className="absolute z-0 top-0 h-[220px] -left-3 -right-3 pointer-events-none overflow-hidden"
         >
           <Image
             src={ASSETS.SPARKMATES.HORIZON}

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/SkillsAndLinksSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/SkillsAndLinksSection.tsx
@@ -124,43 +124,6 @@ function CategoryCard({
   );
 }
 
-function OtherLinksCard({
-  links,
-  onOpenExternal,
-}: {
-  links: string[];
-  onOpenExternal: (url: string) => void;
-}) {
-  return (
-    <div className="rounded-2xl border border-white/15 bg-[rgba(255,255,255,0.04)] px-6 py-5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)]">
-      <div className="mb-3 flex items-center gap-3">
-        <SkillSectionIcon type="links" />
-        <Text variant="body-lg" className="text-white" weight="medium">
-          Other Links
-        </Text>
-      </div>
-      {links.length > 0 ? (
-        <div className="space-y-2">
-          {links.map((link, index) => (
-            <Button
-              key={`${link}-${index}`}
-              variant="ghost"
-              className="h-auto w-full justify-start rounded-xl border border-white/20 bg-[#091734] px-3 py-2 text-left text-white"
-              onClick={() => onOpenExternal(link)}
-            >
-              <span className="block truncate">{link}</span>
-            </Button>
-          ))}
-        </div>
-      ) : (
-        <Text variant="body-sm" className="text-[#C1C7CD]">
-          No links yet.
-        </Text>
-      )}
-    </div>
-  );
-}
-
 const StyledInputContainer = ({ children }: { children: React.ReactNode }) => (
   <div className="relative group w-full rounded-[8px] p-[1px] focus-within:p-[2px] bg-[#737373] hover:bg-gradient-to-r focus-within:bg-gradient-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_0_10px_rgba(251,44,54,0.35),0_0_20px_rgba(240,177,0,0.3),0_0_32px_rgba(43,127,255,0.4)] transition-all duration-300 ease-in-out">
     {children}
@@ -251,13 +214,11 @@ export function SkillsAndLinksSection({
           chips={profile.toolsAndTechnologies ?? []}
           iconType="tools"
         />
-        <OtherLinksCard links={profile.otherLinks ?? []} onOpenExternal={(url) => {window.open( url, '_blank');}} />
       </div>
 
       {profile.technicalSkills?.length === 0 &&
       profile.learningInterests?.length === 0 &&
-      profile.toolsAndTechnologies?.length === 0 &&
-      profile.otherLinks?.length === 0 ? (
+      profile.toolsAndTechnologies?.length === 0 ? (
         <Button
           variant="outline"
           className="w-full border-white/25 bg-white/5 text-white"

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/SuggestedPeopleSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/SuggestedPeopleSection.tsx
@@ -30,7 +30,7 @@ export const SuggestedPeopleSection = ({
         className="text-white placeholder:text-[#C1C7CD]"
       />
 
-      <div className="mt-4 flex items-center justify-between gap-3">
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
         <Text variant="body-lg" className="text-white">
           Suggested To You
         </Text>

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
@@ -16,6 +16,10 @@ import { ASSETS } from "@/lib/constants/assets";
 import { SparkmatesSource, useSparkmateProfile, useSuggestedSparkmates } from "../.."; 
 import { PublicSkillsAndLinksSection } from "./components/PublicSkillsAndLinksSection";
 import { ComingSoonPlaceholder } from "../ComingSoonPlaceholder";
+import { usePublicMemberProjects } from "../../hooks/usePublicMemberProjects";
+import { ProjectCard } from "../SparkmatesOwnerView/components/ProjectCard";
+import { GradientProfilePicture } from "../SparkmatesOwnerView/components/GradientProfilePicture";
+import { ConnectedSuggestedCard } from "../SparkmatesOwnerView/components/ConnectedSuggestedCard";
 
 const viewIcon = (
   <svg
@@ -46,26 +50,6 @@ const searchIcon = (
     <path d="m20 20-3.5-3.5" strokeLinecap="round" />
   </svg>
 );
-
-// TODO: Replace with actual assets and data from nextjs public assets
-const FIGMA_ASSETS = {
-  profileCard:
-    "https://www.figma.com/api/mcp/asset/3b8f15f0-f794-48d7-90f6-7463afc9d894",
-  profileRing:
-    "https://www.figma.com/api/mcp/asset/323fd0a6-f443-4caf-abc2-779db7ae33f3",
-  suggestedRing:
-    "https://www.figma.com/api/mcp/asset/a40a5418-1468-4827-bd4c-4527aa87f5ea",
-  customLinkGradient:
-    "https://www.figma.com/api/mcp/asset/487a6240-2dc1-485b-b27c-b192f5ff9947",
-  projectOne:
-    "https://www.figma.com/api/mcp/asset/09b49507-b6fe-4d0f-9332-6444a16245d7",
-  projectTwo:
-    "https://www.figma.com/api/mcp/asset/902a5aa1-eaa6-4a5e-8b70-7dd296a0102f",
-  projectThree:
-    "https://www.figma.com/api/mcp/asset/c806405e-7622-4201-a669-939b69396d7f",
-  badge:
-    "https://www.figma.com/api/mcp/asset/298196a1-6987-40f4-b7ee-621502d4cac0",
-};
 
 // function resolveAuthenticatedAvatar(user: ReturnType<typeof useAuthContext>["user"]) {
 //   if (!user) return null;
@@ -150,75 +134,6 @@ function SocialGlyph({ type }: { type: "github" | "linkedin" | "website" }) {
   );
 }
 
-function GradientProfilePicture({
-  src,
-  alt,
-  fallback,
-}: {
-  src?: string;
-  alt: string;
-  fallback: string;
-}) {
-  return (
-    <div className="relative h-43 w-43 shrink-0">
-      <img
-        src={FIGMA_ASSETS.profileRing}
-        alt=""
-        aria-hidden
-        className="absolute inset-0 h-full w-full object-contain"
-      />
-      <div className="absolute left-1/2 top-1/2 h-41 w-41 -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-full">
-        <Avatar
-          src={src}
-          alt={alt}
-          fallback={fallback}
-          className="h-full w-full rounded-full"
-        />
-      </div>
-    </div>
-  );
-}
-
-function ConnectedSuggestedCard({
-  avatarUrl,
-  name,
-  bio,
-}: {
-  avatarUrl?: string;
-  name: string;
-  bio: string;
-}) {
-  return (
-    <article className="relative flex items-center pl-11.5">
-      <div className="w-full overflow-hidden rounded-r-2xl border border-white/20 bg-[rgba(255,255,255,0.05)] pl-16 pr-4 py-3.5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)]">
-        <Text variant="body-lg" className="truncate text-white" weight="medium">
-          {name}
-        </Text>
-        <Text variant="body-sm" className="truncate text-[#E5E5E5]">
-          {bio}
-        </Text>
-      </div>
-
-      <div className="absolute left-0 top-1/2 h-23.5 w-23.5 -translate-y-1/2">
-        <img
-          src={FIGMA_ASSETS.suggestedRing}
-          alt=""
-          aria-hidden
-          className="absolute inset-0 h-full w-full object-contain"
-        />
-        <div className="absolute left-1/2 top-1/2 h-21.5 w-21.5 -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-full">
-          <Avatar
-            src={avatarUrl}
-            alt={name}
-            fallback={name.charAt(0)}
-            className="h-full w-full rounded-full"
-          />
-        </div>
-      </div>
-    </article>
-  );
-}
-
 function Divider() {
   return (
     <div className="h-px w-full bg-[linear-gradient(90deg,#0F2449_0%,#2A4F91_50%,#0F2449_100%)]" />
@@ -256,28 +171,6 @@ const SPARK_BADGE = {
   variantId: "id",
 } as const;
 
-function ProjectCard({ image }: { image: string }) {
-  return (
-    <article className="rounded-2xl border border-white/15 bg-[rgba(255,255,255,0.04)] p-5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)]">
-      <Text variant="body" className="text-white" weight="medium">
-        Project Title
-      </Text>
-      <Text variant="body-sm" className="mt-1 text-[#C1C7CD]">
-        Month Year · Month Year
-      </Text>
-      <Text variant="body-sm" className="mt-1 text-[#E5E5E5]">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-        ullamcorper sed eros, non sollicitudin.
-      </Text>
-      <img
-        src={image}
-        alt="Project preview"
-        className="mt-2 h-20 w-full rounded-md object-cover"
-      />
-    </article>
-  );
-}
-
 export function ProfilePublicView({
   gdgId,
   source,
@@ -286,9 +179,6 @@ export function ProfilePublicView({
   source: SparkmatesSource;
 }) {
   const [search, setSearch] = useState("");
-  const [starredCustomButtons, setStarredCustomButtons] = useState<Set<number>>(
-    () => new Set([0]),
-  );
 
   const {
     data: profile,
@@ -302,6 +192,8 @@ export function ProfilePublicView({
     viewerGdgId: profile?.gdgId,
     // viewerPortfolio: profile?.portfolio ?? null,
   });
+
+  const projectsQuery = usePublicMemberProjects(gdgId);
 
   // const isOwner = useMemo(() => {
   //   return Boolean(
@@ -379,20 +271,14 @@ export function ProfilePublicView({
     // user?.user_metadata?.full_name ||
     profile.gdgId;
 
-  const avatarUrl = ASSETS.BRANDING.GDG_LOGO_WEBP; //resolveAuthenticatedAvatar(user);
+  const avatarUrl = profile?.avatarUrl || ASSETS.PROFILE.DEFAULT_AVATAR;
 
   const customLinks = (profile?.otherLinks ?? []).map((url) => ({
     title: getLinkTitle(url),
     url,
   }));
 
-  const badgeCards = [1, 2, 3];
-
-  const projectImages = [
-    FIGMA_ASSETS.projectOne,
-    FIGMA_ASSETS.projectTwo,
-    FIGMA_ASSETS.projectThree,
-  ];
+  const projectList = projectsQuery.data || [];
 
   const socialLinks = [
     { key: "github", url: profile?.githubUrl, label: "GitHub" },
@@ -408,18 +294,6 @@ export function ProfilePublicView({
     },
   ] as const;
 
-  const toggleStar = (index: number) => {
-    setStarredCustomButtons((prev) => {
-      const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
-      } else {
-        next.add(index);
-      }
-      return next;
-    });
-  };
-
   return (
     <CosmosParticles
       particleColors={["#ffffff", "#4285f4"]}
@@ -430,14 +304,14 @@ export function ProfilePublicView({
       moveParticlesOnHover
       alphaParticles={true}
       disableRotation={false}
-      className="min-h-screen bg-[#010B1D] bg-[radial-gradient(circle_at_30%_55%,rgba(66,133,244,0.2),transparent_30%),radial-gradient(circle_at_58%_73%,rgba(249,171,0,0.14),transparent_25%)] px-6 pb-24 pt-36 text-white"
+      className="min-h-screen overflow-x-hidden bg-[#010B1D] bg-[radial-gradient(circle_at_30%_55%,rgba(66,133,244,0.2),transparent_30%),radial-gradient(circle_at_58%_73%,rgba(249,171,0,0.14),transparent_25%)] px-3 sm:px-6 pb-24 pt-24 sm:pt-36 text-white"
     >
-      <div className="relative min-h-screen w-full overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
+      <div className="relative w-full">
+        <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden hidden sm:block">
           <SparkmatesRainbowStreak />
         </div>
 
-        <div className="relative z-10 mx-auto grid w-full max-w-325 gap-8 lg:grid-cols-[1fr_380px] lg:items-start">
+        <div className="relative z-10 mx-auto grid w-full max-w-325 gap-6 lg:grid-cols-[1fr_380px] lg:items-start">
           <FadeInSection className="p-0" delay={0.02}>
             <div className="flex flex-wrap items-center justify-between gap-3">
               <Text variant="heading-5" className="text-white">
@@ -446,15 +320,85 @@ export function ProfilePublicView({
             </div>
 
             <div className="mt-6 p-0">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="sm:hidden relative">
+                <div
+                  className="absolute z-0 top-0 h-[220px] -left-3 -right-3 pointer-events-none overflow-hidden"
+                >
+                  <Image
+                    src={ASSETS.SPARKMATES.HORIZON}
+                    alt=""
+                    aria-hidden
+                    fill
+                    className="object-cover"
+                    style={{ objectPosition: "50% 65%" }}
+                    priority
+                  />
+                  <div className="absolute inset-x-0 top-0 h-1/2 bg-gradient-to-b from-[#010B1D] to-transparent" />
+                  <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-[#010B1D] to-transparent" />
+                </div>
+
+                <div className="relative z-10 flex justify-center pt-10">
+                  <GradientProfilePicture
+                    size="sm"
+                    src={avatarUrl}
+                    alt={displayName}
+                    fallback={displayName.charAt(0)}
+                  />
+                </div>
+
+                <div className="relative z-10 flex flex-col items-center text-center px-4 mt-3 pb-2">
+                  <Text variant="heading-6" className="text-white leading-tight" weight="bold">
+                    {displayName}
+                  </Text>
+
+                  <Text variant="body-sm" className="text-[#C1C7CD] mt-1">
+                    {profile?.program || "Program and Year not set"}
+                  </Text>
+
+                  <div className="mt-2.5 flex flex-wrap justify-center gap-2">
+                    <Badge variant={SPARK_BADGE.variantYellow as never}>UI/UX</Badge>
+                    <Badge variant={SPARK_BADGE.variantRed as never}>Marketing</Badge>
+                    <Badge variant={SPARK_BADGE.variantId as never}>{profile.gdgId}</Badge>
+                  </div>
+
+                  <Text
+                    variant="body-sm"
+                    className="mt-3 max-w-xs text-[#E5E5E5] leading-relaxed"
+                  >
+                    {profile?.bio ||
+                      "Share your story to let sparkmates know what you are building."}
+                  </Text>
+
+                  <div className="mt-4 flex gap-2 justify-center">
+                    {socialLinks.map((social) => (
+                      <Button
+                        key={social.key}
+                        variant="ghost"
+                        size="sm"
+                        title={social.label}
+                        disabled={!social.url}
+                        className="h-8 w-8 rounded-full border border-white/25 bg-[#091734] p-0 text-[11px] text-white disabled:opacity-40"
+                        onClick={() => {
+                          if (!social.url) return;
+                          openExternal(social.url);
+                        }}
+                      >
+                        <SocialGlyph type={social.key} />
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="hidden sm:flex sm:flex-row sm:items-start sm:gap-4 sm:justify-between mt-6">
                 <div className="flex min-w-0 items-start gap-4">
                   <GradientProfilePicture
-                    src={avatarUrl ?? FIGMA_ASSETS.profileCard}
+                    src={avatarUrl}
                     alt={displayName}
                     fallback={displayName.charAt(0)}
                   />
 
-                  <div className="min-w-0">
+                  <div className="min-w-0 pt-2">
                     <Text
                       variant="heading-6"
                       className="text-white"
@@ -462,24 +406,17 @@ export function ProfilePublicView({
                     >
                       {displayName}
                     </Text>
-                    <Text variant="body-sm" className="text-[#C1C7CD]">
-                      {profile?.program ||
-                        "Program and Year not set"}
+                    <Text variant="body-sm" className="text-[#C1C7CD] mt-1">
+                      {profile?.program || "Program and Year not set"}
                     </Text>
                     <div className="mt-2 flex flex-wrap gap-2">
-                      <Badge variant={SPARK_BADGE.variantYellow as never}>
-                        UI/UX
-                      </Badge>
-                      <Badge variant={SPARK_BADGE.variantRed as never}>
-                        Marketing
-                      </Badge>
-                      <Badge variant={SPARK_BADGE.variantId as never}>
-                        {profile.gdgId}
-                      </Badge>
+                      <Badge variant={SPARK_BADGE.variantYellow as never}>UI/UX</Badge>
+                      <Badge variant={SPARK_BADGE.variantRed as never}>Marketing</Badge>
+                      <Badge variant={SPARK_BADGE.variantId as never}>{profile.gdgId}</Badge>
                     </div>
                     <Text
                       variant="body-sm"
-                      className="mt-2 max-w-130 text-[#E5E5E5]"
+                      className="mt-2 max-w-sm text-[#E5E5E5] leading-relaxed"
                     >
                       {profile?.bio ||
                         "Share your story to let sparkmates know what you are building."}
@@ -507,7 +444,7 @@ export function ProfilePublicView({
               </div>
             </div>
 
-            <div className="mt-8 space-y-8">
+            <div className="mt-6 space-y-6">
               <section className="space-y-4">
                 <div className="flex items-center justify-between">
                   <Text variant="heading-6" gradient="white-blue" weight="bold">
@@ -529,30 +466,21 @@ export function ProfilePublicView({
                           "#00C950",
                           "#2B7FFF",
                         ]}
-                        className={
-                          starredCustomButtons.has(index)
-                            ? "opacity-100 transition-opacity duration-300"
-                            : "opacity-0 transition-opacity duration-300"
-                        }
+                        className="opacity-100 transition-opacity duration-300"
                       />
                       <div className="flex items-start justify-between">
-                        <div>
+                        <div className="min-w-0 flex-1">
                           <Text
                             variant="body-lg"
-                            className="text-white"
+                            className="text-white truncate block"
                             weight="medium"
                           >
                             {item.title}
                           </Text>
-                          <Text variant="body" className="text-[#E5E5E5]">
+                          <Text variant="body" className="text-[#E5E5E5] break-all block">
                             {item.url}
                           </Text>
                         </div>
-                        {starredCustomButtons.has(index) && (
-                          <div className="h-8 w-8 flex items-center justify-center text-white text-xl">
-                            ★
-                          </div>
-                        )}
                       </div>
                     </div>
                   ))}
@@ -570,7 +498,6 @@ export function ProfilePublicView({
 
               <PublicSkillsAndLinksSection
                 portfolio={profile}
-                onOpenExternal={openExternal}
               />
 
               <Divider />
@@ -590,9 +517,19 @@ export function ProfilePublicView({
                   </Button>
                 </div>
                 <div className="space-y-3.5">
-                  {projectImages.map((image, index) => (
-                    <ProjectCard key={`project-${index}`} image={image} />
-                  ))}
+                  {projectsQuery.isLoading ? (
+                    <Text variant="body-sm" className="text-zinc-500">
+                      Loading projects...
+                    </Text>
+                  ) : projectList.length > 0 ? (
+                    projectList.map((project: any) => (
+                      <ProjectCard key={project.id} project={project} />
+                    ))
+                  ) : (
+                    <div className="rounded-2xl border border-white/15 bg-[rgba(255,255,255,0.04)] px-5 py-4 text-center text-[#C1C7CD]">
+                      <Text variant="body-sm">No projects added yet.</Text>
+                    </div>
+                  )}
                 </div>
               </section>
 
@@ -668,7 +605,7 @@ export function ProfilePublicView({
                       className="rounded-2xl border border-white/20 bg-[rgba(255,255,255,0.04)] p-4 text-center shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)]"
                     >
                       <img
-                        src={FIGMA_ASSETS.badge}
+                        src={ASSETS.PROFILE.AVATAR_RING}
                         alt="Badge"
                         className="mx-auto h-20 w-20 object-cover"
                       />
@@ -697,7 +634,7 @@ export function ProfilePublicView({
               className="text-white placeholder:text-[#C1C7CD]"
             />
 
-            <div className="mt-4 flex items-center justify-between gap-3">
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
               <Text variant="body-lg" className="text-white">
                 Suggested To You
               </Text>
@@ -718,6 +655,7 @@ export function ProfilePublicView({
                   avatarUrl={member.avatarUrl ?? undefined}
                   name={member.name}
                   bio={member.bio}
+                  gdgId={member.gdgId}
                 />
               ))}
 

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/components/PublicSkillsAndLinksSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/components/PublicSkillsAndLinksSection.tsx
@@ -1,11 +1,11 @@
 import { SparkmatesProfile } from "@/features/sparkmates/types";
-import { Badge, Button, Text } from "@packages/spark-ui"; 
+import { Badge, Text } from "@packages/spark-ui";
 
 const SPARK_BADGE = {
   variantBlue: "blue",
 } as const;
 
-function SkillSectionIcon({ type }: { type: "technical" | "learning" | "tools" | "links" }) {
+function SkillSectionIcon({ type }: { type: "technical" | "learning" | "tools" }) {
   if (type === "technical") {
     return (
       <svg viewBox="0 0 24 24" className="h-5 w-5 text-white" fill="none" stroke="currentColor" strokeWidth="2">
@@ -30,11 +30,6 @@ function SkillSectionIcon({ type }: { type: "technical" | "learning" | "tools" |
     );
   }
 
-  return (
-    <svg viewBox="0 0 24 24" className="h-5 w-5 text-white" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M10 14 21 3M14 3h7v7M3 10v11h11" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
 }
 
 function CategoryCard({
@@ -71,54 +66,14 @@ function CategoryCard({
   );
 }
 
-function OtherLinksCard({
-  links,
-  onOpenExternal,
-}: {
-  links: string[];
-  onOpenExternal: (url: string) => void;
-}) {
-  return (
-    <div className="rounded-2xl border border-white/15 bg-[rgba(255,255,255,0.04)] px-6 py-5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)]">
-      <div className="mb-3 flex items-center gap-3">
-        <SkillSectionIcon type="links" />
-        <Text variant="body-lg" className="text-white" weight="medium">
-          Other Links
-        </Text>
-      </div>
-      {links.length > 0 ? (
-        <div className="space-y-2">
-          {links.map((link, index) => (
-            <Button
-              key={`${link}-${index}`}
-              variant="ghost"
-              className="h-auto w-full justify-start rounded-xl border border-white/20 bg-[#091734] px-3 py-2 text-left text-white"
-              onClick={() => onOpenExternal(link)}
-            >
-              <span className="block truncate">{link}</span>
-            </Button>
-          ))}
-        </div>
-      ) : (
-        <Text variant="body-sm" className="text-[#C1C7CD]">
-          No links yet.
-        </Text>
-      )}
-    </div>
-  );
-}
-
 export function PublicSkillsAndLinksSection({
   portfolio,
-  onOpenExternal,
 }: {
   portfolio: SparkmatesProfile | null;
-  onOpenExternal: (url: string) => void;
 }) {
   const skills = portfolio?.technicalSkills ?? [];
   const interests = portfolio?.learningInterests ?? [];
   const tools = portfolio?.toolsAndTechnologies ?? [];
-  const otherLinks = portfolio?.otherLinks ?? [];
 
   return (
     <section className="space-y-4 pt-6">
@@ -132,7 +87,6 @@ export function PublicSkillsAndLinksSection({
         <CategoryCard title="Technical Skills" chips={skills} iconType="technical" />
         <CategoryCard title="Learning Interests" chips={interests} iconType="learning" />
         <CategoryCard title="Tools & Technologies" chips={tools} iconType="tools" />
-        <OtherLinksCard links={otherLinks} onOpenExternal={onOpenExternal} />
       </div>
     </section>
   );

--- a/apps/nexus-web/src/features/sparkmates/hooks/usePublicMemberProjects.ts
+++ b/apps/nexus-web/src/features/sparkmates/hooks/usePublicMemberProjects.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMemberProjects } from "../api/memberProjects";
+
+export function usePublicMemberProjects(gdgId?: string) {
+  return useQuery({
+    queryKey: ["publicMemberProjects", gdgId],
+    queryFn: () => {
+      if (!gdgId) throw new Error("No GDG ID provided");
+      return getMemberProjects(gdgId);
+    },
+    enabled: Boolean(gdgId),
+  });
+}


### PR DESCRIPTION
This pull request makes several improvements and refactors to the Sparkmates profile owner and public views, focusing on layout consistency, code reuse, and UI polish. The main changes include removing duplicated components, improving responsive layouts, and enhancing the display of custom buttons and project sections.

**Component reuse and code cleanup:**

- Removed duplicated `GradientProfilePicture`, `ConnectedSuggestedCard`, and `ProjectCard` components from `ProfilePublicView.tsx` and replaced them with imports from the owner view components, ensuring a single source of truth for these UI elements. [[1]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R19-R22) [[2]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L153-L221) [[3]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L259-L280)
- Removed the unused `OtherLinksCard` component from `SkillsAndLinksSection.tsx` and its usage, streamlining the code and UI. [[1]](diffhunk://#diff-9f5c999c764dc08b454e51f7ac692d159d3b4b01e58abb04e56cd18e44ff6c3cL127-L163) [[2]](diffhunk://#diff-9f5c999c764dc08b454e51f7ac692d159d3b4b01e58abb04e56cd18e44ff6c3cL254-R221)

**Layout and styling improvements:**

- Added `overflow-x-hidden` to the main container and adjusted padding and spacing to improve layout consistency and prevent unwanted horizontal scrolling on both owner and public profile views. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL130-R133) [[2]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L433-R314)
- Improved responsive design by updating class names and comments for horizon background images, and making grid gaps and visibility of certain elements more consistent across screen sizes. [[1]](diffhunk://#diff-81fce7e9b91e7b738c1b34e86afa0956835b5d629d40178d92f09eb11165628bL125-R127) [[2]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L433-R314)

**Custom buttons and links enhancements:**

- Restored and improved the display of custom buttons in the owner profile view, making the section visible and enhancing truncation and layout for long titles and URLs. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR22) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL174-R175) [[3]](diffhunk://#diff-0f432ab37d65fc6b947c086bcf7f827e538ea6f5139d437af82188bf7269ffe5L95-R111)

**Project section and data fetching:**

- Updated the public profile view to fetch and display projects using the `usePublicMemberProjects` hook and the shared `ProjectCard` component, replacing hardcoded images and improving data accuracy. [[1]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R19-R22) [[2]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R196-R197) [[3]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L382-R281)

**Minor UI tweaks:**

- Allowed wrapping of suggested people cards to avoid overflow on smaller screens.

These changes collectively make the Sparkmates profile views more maintainable, consistent, and visually robust.