### PR TITLE
refactor(nexus-web): improve hero and impact card components in home page

### DIFF
--- a/apps/nexus-web/src/features/home/components/hero-section.tsx
+++ b/apps/nexus-web/src/features/home/components/hero-section.tsx
@@ -4,10 +4,10 @@ import {
   motion,
   useReducedMotion,
   useScroll,
-  useSpring,
   useTransform,
   type MotionValue,
 } from "motion/react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Button, Container, Stack, Text } from "@packages/spark-ui";
 import Link from "next/link";
 import { ASSETS } from "@/lib/constants/assets";
@@ -29,6 +29,14 @@ const HERO_LAYERS = [
   { src: ASSETS.HOME.HERO.LAYER_F5, speed: 0.08, zIndex: 1 },
   { src: ASSETS.HOME.HERO.LAYER_BG, speed: 0.1, zIndex: 0 },
 ] as const;
+
+const MOBILE_DISABLED_LAYERS = new Set<string>([
+  ASSETS.HOME.HERO.LAYER_B1,
+  ASSETS.HOME.HERO.LAYER_B2,
+  ASSETS.HOME.HERO.LAYER_F1,
+  ASSETS.HOME.HERO.LAYER_F4,
+  ASSETS.HOME.HERO.LAYER_F5,
+]);
 
 /* ------------------------------------------------------------------ */
 /*  CTA entrance animation variants                                   */
@@ -58,29 +66,44 @@ interface ParallaxLayerProps {
   src: string;
   speed: number;
   zIndex: number;
-  scrollY: MotionValue<number>;
+  scrollYProgress: MotionValue<number>;
+  distance: number;
+  isMobileViewport: boolean;
+  disableParallax: boolean;
 }
 
-function ParallaxLayer({ src, speed, zIndex, scrollY }: ParallaxLayerProps) {
-  const rawY = useTransform(scrollY, [0, 1000], [0, -1000 * speed]);
-  // Spring-smooth the transform for a less mechanical feel
-  const y = useSpring(rawY, { stiffness: 80, damping: 20, mass: 0.4 });
+const ParallaxLayer = memo(function ParallaxLayer({
+  src,
+  speed,
+  zIndex,
+  scrollYProgress,
+  distance,
+  isMobileViewport,
+  disableParallax,
+}: ParallaxLayerProps) {
+  const y = useTransform(
+    scrollYProgress,
+    [0, 1],
+    [0, -distance * speed],
+  );
 
   return (
     <motion.div
-      style={{ y, zIndex }}
-      className="absolute inset-0 will-change-transform"
+      style={{ y: disableParallax ? 0 : y, zIndex }}
+      className={`absolute inset-0 ${disableParallax ? "" : "will-change-transform"}`}
     >
       <img
         src={src}
         alt=""
         role="presentation"
         draggable={false}
-        className="h-full w-full object-fill select-none"
+        className={`h-full w-full select-none ${
+          isMobileViewport ? "object-cover object-center" : "object-fill"
+        }`}
       />
     </motion.div>
   );
-}
+});
 
 /* ------------------------------------------------------------------ */
 /*  HeroSection                                                       */
@@ -88,22 +111,70 @@ function ParallaxLayer({ src, speed, zIndex, scrollY }: ParallaxLayerProps) {
 
 export function HeroSection() {
   const prefersReduced = useReducedMotion();
+  const sectionRef = useRef<HTMLElement>(null);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
 
-  // Single scroll listener shared across all parallax layers
-  const { scrollY } = useScroll();
-  const ctaOpacity = useTransform(scrollY, [0, 400], [1, 0]);
-  const ctaY = useTransform(scrollY, [0, 400], [0, -60]);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 1023px)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobileViewport(event.matches);
+    };
+
+    setIsMobileViewport(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, []);
+
+  // Scope hero motion to this section so transforms remain predictable.
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start start", "end start"],
+  });
+  const ctaY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    [0, isMobileViewport ? 0 : -48],
+  );
+  const desktopCtaOpacity = useTransform(
+    scrollYProgress,
+    [0, 0.8, 1],
+    [1, 0.9, 0.75],
+  );
+
+  const ctaOpacity = isMobileViewport ? 1 : desktopCtaOpacity;
+
+  const parallaxDistance = isMobileViewport ? 120 : 300;
+  const headingVariant = isMobileViewport ? "heading-4" : "heading-2";
+  const bodyVariant = isMobileViewport ? "body-sm" : "body";
+  const ctaButtonSize = isMobileViewport ? "md" : "lg";
+  const disableParallax = Boolean(prefersReduced);
+  const activeLayers = useMemo(() => {
+    if (!isMobileViewport) {
+      return HERO_LAYERS;
+    }
+
+    return HERO_LAYERS.filter((layer) => !MOBILE_DISABLED_LAYERS.has(layer.src));
+  }, [isMobileViewport]);
 
   return (
-    <section className="relative h-screen w-full overflow-hidden">
+    <section
+      ref={sectionRef}
+      className="relative h-[100svh] min-h-[560px] w-full overflow-hidden"
+    >
       {/* Parallax image layers */}
-      {HERO_LAYERS.map((layer) => (
+      {activeLayers.map((layer) => (
         <ParallaxLayer
           key={layer.src}
           src={layer.src}
           speed={layer.speed}
           zIndex={layer.zIndex}
-          scrollY={scrollY}
+          scrollYProgress={scrollYProgress}
+          distance={parallaxDistance}
+          isMobileViewport={isMobileViewport}
+          disableParallax={disableParallax}
         />
       ))}
 
@@ -113,7 +184,11 @@ export function HeroSection() {
         className="absolute inset-0 z-40 flex items-center justify-center"
       >
         <Container>
-          <Stack align="center" justify="center" className="h-screen">
+          <Stack
+            align="center"
+            justify="center"
+            className="h-[100svh] min-h-[560px]"
+          >
             <motion.div
               variants={prefersReduced ? undefined : ctaContainerVariants}
               initial="hidden"
@@ -125,11 +200,11 @@ export function HeroSection() {
               >
                 <Text
                   as="h1"
-                  variant="heading-1"
+                  variant={headingVariant}
                   align="center"
                   gradient="white-blue"
                   weight="bold"
-                  className="text-4xl md:text-5xl lg:text-6xl leading-tight"
+                  className="leading-tight"
                 >
                   Bridging the gap between theory and practice.
                 </Text>
@@ -140,10 +215,10 @@ export function HeroSection() {
                 className="mt-4"
               >
                 <Text
-                  variant="body"
+                  variant={bodyVariant}
                   align="center"
                   weight="bold"
-                  className="text-white max-w-3xl mx-auto leading-relaxed"
+                  className="text-white max-w-[54ch] mx-auto leading-relaxed"
                 >
                   GDG PUP helps student developers grow through real projects,
                   events, and mentorship connecting classroom learning to
@@ -153,9 +228,9 @@ export function HeroSection() {
 
               <motion.div
                 variants={prefersReduced ? undefined : ctaItemVariants}
-                className="mt-8 inline-block"
+                className="mt-6 md:mt-8 inline-block"
               >
-                <Button asChild variant="default" size="lg">
+                <Button asChild variant="default" size={ctaButtonSize}>
                   <Link href="/signin">Spark your Journey</Link>
                 </Button>
               </motion.div>

--- a/apps/nexus-web/src/features/home/components/impact-card.tsx
+++ b/apps/nexus-web/src/features/home/components/impact-card.tsx
@@ -1,11 +1,13 @@
+"use client";
+
+import { motion } from "motion/react";
 import Image, { type StaticImageData } from "next/image";
+import { useEffect, useRef, useState } from "react";
+import { Card, CardContent, CardHeader, Text } from "@packages/spark-ui";
 
 interface ImpactCardProps {
   color: string;
-  corner: string | StaticImageData;
   title: string;
-  logo: string | StaticImageData;
-  logoAlt: string;
   description: string;
   image: string | StaticImageData;
   imageAlt: string;
@@ -14,58 +16,184 @@ interface ImpactCardProps {
 
 export function ImpactCard({
   color,
-  corner,
   title,
-  logo,
-  logoAlt,
   description,
   image,
   imageAlt,
   className = "",
 }: ImpactCardProps) {
+  const [hovered, setHovered] = useState(false);
+  const [dims, setDims] = useState({ w: 0, h: 0 });
+  const [offset, setOffset] = useState(0);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
+  const offsetRef = useRef(0);
+
+  const T = 5;
+  const CORNER = 44;
+  const R = 20;
+  const SEG = 72;
+  const SPEED = 3;
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+
+    const ro = new ResizeObserver(() => {
+      setDims({ w: el.offsetWidth, h: el.offsetHeight });
+    });
+
+    ro.observe(el);
+    setDims({ w: el.offsetWidth, h: el.offsetHeight });
+
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!hovered) {
+      cancelAnimationFrame(rafRef.current);
+      return;
+    }
+
+    const tick = () => {
+      offsetRef.current -= SPEED;
+      setOffset(offsetRef.current);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [hovered]);
+
+  const { w, h } = dims;
+  const perimeter = w > 0 ? 2 * (w + h) - 8 * R + 2 * Math.PI * R : 0;
+  const snakes = [0, 0.25, 0.5, 0.75].map((frac) => frac * perimeter);
+  const path =
+    w > 0
+      ? `M ${R},0 H ${w - R} A ${R},${R} 0 0 1 ${w},${R} V ${h - R} A ${R},${R} 0 0 1 ${w - R},${h} H ${R} A ${R},${R} 0 0 1 0,${h - R} V ${R} A ${R},${R} 0 0 1 ${R},0 Z`
+      : "";
+
   return (
-    <article
-      className={`pointer-events-none relative h-full w-full max-w-75 rounded-[28px] flex flex-col gap-6 border bg-[#1a2539] p-6 ${className}`}
-      style={{ borderColor: color }}
+    <motion.article
+      ref={cardRef}
+      className={`relative h-full w-full rounded-[28px] ${className}`}
+      onHoverStart={() => setHovered(true)}
+      onHoverEnd={() => setHovered(false)}
+      animate={{ y: hovered ? -6 : 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
     >
-      <div className="pointer-events-none absolute -inset-1 rounded-[30px]">
-        <Image
-          src={corner}
-          alt=""
-          aria-hidden
-          fill
-          draggable={false}
-          className="pointer-events-none select-none rounded-[30px] object-fill"
-        />
-      </div>
-
-      <div className="flex flex-1 flex-col gap-3">
-        <div className="flex items-start justify-between gap-4">
-          <h3 className="text-2xl leading-8 font-bold text-white">{title}</h3>
-          <Image
-            src={logo}
-            alt={logoAlt}
-            width={48}
-            height={48}
-            draggable={false}
-            className="h-12 w-12 object-contain pointer-events-none select-none"
+      {!hovered && (
+        <>
+          <div
+            className="absolute pointer-events-none z-10"
+            style={{
+              top: -2,
+              left: -2,
+              width: CORNER,
+              height: CORNER,
+              borderTop: `${T}px solid ${color}`,
+              borderLeft: `${T}px solid ${color}`,
+              borderRadius: "20px 0 0 0",
+            }}
           />
+          <div
+            className="absolute pointer-events-none z-10"
+            style={{
+              top: -2,
+              right: -2,
+              width: CORNER,
+              height: CORNER,
+              borderTop: `${T}px solid ${color}`,
+              borderRight: `${T}px solid ${color}`,
+              borderRadius: "0 20px 0 0",
+            }}
+          />
+          <div
+            className="absolute pointer-events-none z-10"
+            style={{
+              bottom: -2,
+              left: -2,
+              width: CORNER,
+              height: CORNER,
+              borderBottom: `${T}px solid ${color}`,
+              borderLeft: `${T}px solid ${color}`,
+              borderRadius: "0 0 0 20px",
+            }}
+          />
+          <div
+            className="absolute pointer-events-none z-10"
+            style={{
+              bottom: -2,
+              right: -2,
+              width: CORNER,
+              height: CORNER,
+              borderBottom: `${T}px solid ${color}`,
+              borderRight: `${T}px solid ${color}`,
+              borderRadius: "0 0 20px 0",
+            }}
+          />
+        </>
+      )}
+
+      {hovered && w > 0 && (
+        <svg
+          className="absolute pointer-events-none z-10"
+          style={{ top: 0, left: 0, overflow: "visible" }}
+          width={w}
+          height={h}
+        >
+          {snakes.map((startOffset, i) => (
+            <path
+              key={i}
+              d={path}
+              fill="none"
+              stroke={color}
+              strokeWidth={T}
+              strokeLinecap="round"
+              strokeDasharray={`${SEG} ${perimeter - SEG}`}
+              strokeDashoffset={-(startOffset + offset)}
+            />
+          ))}
+        </svg>
+      )}
+
+      <Card
+        className="h-full border bg-[#1a2539]"
+        style={{
+          borderColor: color,
+          boxShadow: hovered ? `0 0 24px 2px ${color}44` : "none",
+          transition: "box-shadow 0.25s ease",
+        }}
+      >
+        <CardHeader className="px-5 pt-5 pb-2 text-center">
+          <Text variant="heading-6" weight="semibold" align="center" className="text-white">
+            {title}
+          </Text>
+        </CardHeader>
+
+        <CardContent className="px-4 pt-1 pb-2">
+          <Text variant="body-sm" align="center" className="text-gray-300">
+            {description}
+          </Text>
+        </CardContent>
+
+        <div className="relative mx-4 mt-auto mb-4 h-[clamp(130px,20vw,170px)] overflow-hidden rounded-[12px]">
+          <motion.div
+            className="absolute inset-0"
+            animate={{ scale: hovered ? 1.05 : 1 }}
+            transition={{ duration: 0.35, ease: "easeOut" }}
+          >
+            <Image
+              src={image}
+              alt={imageAlt}
+              fill
+              draggable={false}
+              className="object-cover pointer-events-none select-none"
+            />
+          </motion.div>
         </div>
-
-        <p className="font-normal text-lg leading-7 text-white">
-          {description}
-        </p>
-      </div>
-
-      <div className="relative h-47.5 overflow-hidden rounded-3xl">
-        <Image
-          src={image}
-          alt={imageAlt}
-          fill
-          draggable={false}
-          className="object-cover pointer-events-none select-none"
-        />
-      </div>
-    </article>
+      </Card>
+    </motion.article>
   );
 }

--- a/apps/nexus-web/src/features/home/components/impact-section.tsx
+++ b/apps/nexus-web/src/features/home/components/impact-section.tsx
@@ -27,10 +27,7 @@ export function ImpactSection() {
   const impactCards = [
     {
       color: "#2E74FF",
-      corner: ASSETS.HOME.BLUE_CORNER,
       title: "2,000+ Members",
-      logo: ASSETS.HOME.TEAM_ICON,
-      logoAlt: "team icon",
       description:
         "Fostered a vibrant and engaged ecosystem of tech enthusiasts and innovators.",
       image: ASSETS.HOME.BLUE_IMG_PLACEHOLDER,
@@ -38,10 +35,7 @@ export function ImpactSection() {
     },
     {
       color: "#34A853",
-      corner: ASSETS.HOME.GREEN_CORNER,
       title: "Multiple Tech Teams",
-      logo: ASSETS.HOME.TECH_ICON,
-      logoAlt: "tech icon",
       description:
         "Launched specialized teams to drive technical excellence and project execution.",
       image: ASSETS.HOME.GREEN_IMG_PLACEHOLDER,
@@ -49,10 +43,7 @@ export function ImpactSection() {
     },
     {
       color: "#F9AB00",
-      corner: ASSETS.HOME.YELLOW_CORNER,
       title: "Workshops & Hackathons",
-      logo: ASSETS.HOME.LIGHTBULB_ICON,
-      logoAlt: "lightbulb icon",
       description:
         "Organized dozens of high-impact events focused on building and competing.",
       image: ASSETS.HOME.YELLOW_IMG_PLACEHOLDER,
@@ -60,10 +51,7 @@ export function ImpactSection() {
     },
     {
       color: "#EA4335",
-      corner: ASSETS.HOME.RED_CORNER,
       title: "Industry Collaborations",
-      logo: ASSETS.HOME.HANDSHAKE_ICON,
-      logoAlt: "handshake icon",
       description:
         "Bridged the gap between our community and leading professional organizations.",
       image: ASSETS.HOME.RED_IMG_PLACEHOLDER,
@@ -96,20 +84,17 @@ export function ImpactSection() {
           initial={{ opacity: 0, y: 50 }}
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 50 }}
           transition={{ duration: 0.6, delay: 0.1, ease: "easeOut" }}
-          className="mt-35 grid grid-cols-1 auto-rows-fr gap-10 justify-items-stretch md:grid-cols-4 lg:grid-cols-4"
+          className="mt-35 grid grid-cols-1 auto-rows-fr gap-8 justify-items-stretch md:grid-cols-2 lg:grid-cols-4"
         >
           {impactCards.map((card) => (
             <ImpactCard
               key={`${card.color}-${card.title}`}
               color={card.color}
-              corner={card.corner}
               title={card.title}
-              logo={card.logo}
-              logoAlt={card.logoAlt}
               description={card.description}
               image={card.image}
               imageAlt={card.imageAlt}
-              className="justify-between"
+              className="justify-between min-h-[420px]"
             />
           ))}
         </motion.div>


### PR DESCRIPTION
This pull request updates the `HeroSection` and `ImpactCard` components in the home page to improve responsiveness, accessibility, and visual polish. The most significant changes include a major refactor of the parallax hero section for better mobile support and reduced motion, as well as a complete redesign of the impact cards with interactive animated borders and a simplified API.

**Hero Section Improvements:**

- Refactored the parallax effect to use section-scoped scroll tracking, making the animation more predictable and responsive to viewport size. Parallax layers are now selectively disabled on mobile for better performance and clarity, and the section adapts its layout, typography, and CTA button size based on device type. Parallax can be disabled for users who prefer reduced motion. (`apps/nexus-web/src/features/home/components/hero-section.tsx`) 

**Impact Card Redesign:**

- Rebuilt the `ImpactCard` component to feature animated glowing borders on hover using SVG and motion, with a fallback to static corners when not hovered. The card API was simplified by removing unused props like `corner`, `logo`, and `logoAlt`. Layout and styling were improved for consistency and accessibility, and the card's image now animates on hover. (`apps/nexus-web/src/features/home/components/impact-card.tsx`) 

- Updated the `ImpactSection` to use the new `ImpactCard` API, removed references to deprecated props, and adjusted the card grid for better responsiveness on different screen sizes. (`apps/nexus-web/src/features/home/components/impact-section.tsx`) 