### PR TITLE
fix(nexus-web): community showcase learn more not working

### DIFF
--- a/apps/nexus-web/src/features/community-showcase/components/MobileShowcase.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/MobileShowcase.tsx
@@ -9,6 +9,7 @@ import { CarouselArrowIcon } from "./CarouselArrowIcon";
 import { Event, useEvents } from "@/features/events";
 import { useListEvents } from "@/features/events/hooks/useListEvents";
 import { ASSETS } from "@/lib/constants/assets";
+import { useRouter } from "next/navigation";
 
 /**
  * MobileShowcase
@@ -21,6 +22,7 @@ import { ASSETS } from "@/lib/constants/assets";
  *   - Single-card planet carousel with prev/next navigation
  */
 export function MobileShowcase({events } : {events: Event[]}) {
+  const router = useRouter();
   const [mobileEventIndex, setMobileEventIndex] = useState(0);
   const [mobileCarouselScale, setMobileCarouselScale] = useState(1);
 
@@ -267,6 +269,14 @@ export function MobileShowcase({events } : {events: Event[]}) {
             variant="colored"
             subVariant="blue"
             className="mt-10 h-12 w-38 rounded-lg text-xl font-medium"
+            disabled={!EVENTS[mobileEventIndex].id}
+            onClick={() => {
+              const currentEvent = EVENTS[mobileEventIndex];
+              if (!currentEvent?.id) return;
+              router.push(
+                `/events/${currentEvent.id}?title=${encodeURIComponent(currentEvent.title)}`,
+              );
+            }}
           >
             Learn more
           </Button>

--- a/apps/nexus-web/src/features/community-showcase/components/PastEventsCarousel.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/PastEventsCarousel.tsx
@@ -8,6 +8,7 @@ import { CarouselArrowIcon } from "./CarouselArrowIcon";
 import { PlanetCard } from "./PlanetCard";
 import { useListEvents } from "@/features/events/hooks/useListEvents";
 import { ASSETS } from "@/lib/constants/assets";
+import { useRouter } from "next/navigation";
 
 /**
  * PastEventsCarousel
@@ -16,6 +17,8 @@ import { ASSETS } from "@/lib/constants/assets";
  * Auto-scrolls continuously; pauses on hover; supports click-to-step and drag.
  */
 export function PastEventsCarousel() {
+  const router = useRouter();
+
   const {
     trackRef,
     isPastEventsDragging,
@@ -132,6 +135,11 @@ export function PastEventsCarousel() {
                       variant="colored"
                       subVariant="blue"
                       className="mt-5 xl:mt-7 h-10 xl:h-13 min-w-34 shrink-0 whitespace-nowrap rounded-lg px-4 xl:min-w-36"
+                      disabled={!event.id}
+                      onClick={() => {
+                        if (!event.id) return;
+                        router.push(`/events/${event.id}?title=${encodeURIComponent(event.title)}`);
+                      }}
                     >
                       Learn more
                     </Button>

--- a/apps/nexus-web/src/features/events/components/EventDetailSection.tsx
+++ b/apps/nexus-web/src/features/events/components/EventDetailSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Container, Stack, Text } from "@packages/spark-ui"; 
 import type { Event } from "../types";
 import { normalizeEventDescription, splitBoldSegments } from "../utils/description";
@@ -31,6 +31,7 @@ export function EventDetailSection({
   eventId,
   title,
 }: EventDetailSectionProps) { 
+  const router = useRouter();
   const [expanded, setExpanded] = useState(false);
 
   const { data : eventDetail, isLoading, error} = useEvent(eventId)
@@ -99,6 +100,15 @@ export function EventDetailSection({
 
     return `${monthDay}, ${startTime}${endTime ? ` \u2013 ${endTime}` : ""} (${gmt})`;
   }, [eventDetail]);
+
+  const handleBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+      return;
+    }
+
+    router.push("/events");
+  };
 
   return (
     <div
@@ -229,8 +239,9 @@ export function EventDetailSection({
 
       <Container className="relative z-10">
         <Stack gap="md" className="md:gap-5">
-          <Link
-            href="/events"
+          <button
+            type="button"
+            onClick={handleBack}
             className="inline-flex items-center gap-2 text-white/85 hover:text-white transition-colors text-sm md:text-base w-fit"
           >
             <svg
@@ -245,7 +256,7 @@ export function EventDetailSection({
               <path d="M15 18l-6-6 6-6" />
             </svg>
             <span>Back</span>
-          </Link>
+          </button>
 
           <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-black min-h-[260px] md:min-h-[520px]">
             <img


### PR DESCRIPTION
This pull request updates navigation in several event-related components to use the `useRouter` hook from Next.js for improved client-side routing and navigation consistency. It replaces direct `Link` usage or static button handlers with programmatic navigation, adds defensive checks for missing event IDs, and introduces a custom back navigation handler in the event detail view.

Navigation improvements:

* Switched from using `Link` components and static navigation to the `useRouter` hook from Next.js in `MobileShowcase`, `PastEventsCarousel`, and `EventDetailSection`, enabling programmatic navigation and better handling of navigation history. 
* Updated "Learn more" buttons in `MobileShowcase` and `PastEventsCarousel` to use `router.push` for navigation, including proper URL encoding for event titles and disabling the button if the event ID is missing. 
Event detail page enhancements:

* Replaced the "Back" link in `EventDetailSection` with a button that uses a custom `handleBack` function, which tries to navigate back in browser history if possible, or falls back to redirecting to the `/events` page. 

Related Issue
closes #661 