### PR TITLE
chore(onboarding): reference to is_onboarding column instead of isPublic

### DIFF
--- a/apps/nexus-api/src/v1/modules/members/domain/GdgMember.ts
+++ b/apps/nexus-api/src/v1/modules/members/domain/GdgMember.ts
@@ -81,6 +81,7 @@ export type GdgMemberProps = {
   toolsAndTechnologies: string[];
   sectionOrder: SparkmatesSectionId[];
 
+  isOnboarded: boolean | null;
   isPublic: boolean | null;
 };
 

--- a/apps/nexus-api/src/v1/modules/members/infrastructure/SupabaseGdgMemberRepository.ts
+++ b/apps/nexus-api/src/v1/modules/members/infrastructure/SupabaseGdgMemberRepository.ts
@@ -50,6 +50,7 @@ export class SupabaseGdgMemberRepository implements IGdgMemberRepository {
           .filter((item): item is SparkmatesSectionId =>
             isSparkmatesSectionId(item),
           ) || DEFAULT_SPARKMATES_SECTION_ORDER,
+      isOnboarded: row.is_onboarded,
       isPublic: row.is_public,
     });
   }
@@ -78,6 +79,7 @@ export class SupabaseGdgMemberRepository implements IGdgMemberRepository {
       learning_interests: p.learningInterests.join(","),
       tools_and_technologies: p.toolsAndTechnologies.join(","),
       section_order: p.sectionOrder.join(","),
+      is_onboarded: p.isOnboarded,
       is_public: p.isPublic,
 
       created_at: new Date().toISOString(),

--- a/apps/nexus-api/src/v1/types/supabase.types.ts
+++ b/apps/nexus-api/src/v1/types/supabase.types.ts
@@ -381,6 +381,7 @@ export type Database = {
           first_name: string | null
           gdg_id: string
           github_url: string | null
+          is_onboarded: boolean | null
           is_public: boolean | null
           last_name: string | null
           learning_interests: string | null
@@ -409,6 +410,7 @@ export type Database = {
           first_name?: string | null
           gdg_id: string
           github_url?: string | null
+          is_onboarded?: boolean | null
           is_public?: boolean | null
           last_name?: string | null
           learning_interests?: string | null
@@ -437,6 +439,7 @@ export type Database = {
           first_name?: string | null
           gdg_id?: string
           github_url?: string | null
+          is_onboarded?: boolean | null
           is_public?: boolean | null
           last_name?: string | null
           learning_interests?: string | null

--- a/apps/nexus-web/src/app/onboarding/page.tsx
+++ b/apps/nexus-web/src/app/onboarding/page.tsx
@@ -23,7 +23,7 @@ export default function OnboardingPage() {
     }
 
     // Redirect to profile if already onboarded
-    if (status === STATUS.AUTHENTICATED && memberProfile && memberProfile.isPublic !== null) {
+    if (status === STATUS.AUTHENTICATED && memberProfile && memberProfile.isOnboarded) {
       router.push("/sparkmates/me");
     }
   }, [status, memberProfile, router]);

--- a/apps/nexus-web/src/features/authentication/components/RequireAuthenticated.tsx
+++ b/apps/nexus-web/src/features/authentication/components/RequireAuthenticated.tsx
@@ -27,7 +27,7 @@ export const RequireAuthenticated = ({
       if (!memberProfile) return;
 
       // If they haven't completed onboarding, force them to do it unless they are already there
-      if (memberProfile.isPublic === null && pathname !== LINKS.onboarding) {
+      if (!memberProfile.isOnboarded && pathname !== LINKS.onboarding) {
         console.log("Redirecting to onboarding... profile incomplete");
         router.push(LINKS.onboarding);
       }

--- a/apps/nexus-web/src/features/onboarding/hooks/useOnboardingForm.ts
+++ b/apps/nexus-web/src/features/onboarding/hooks/useOnboardingForm.ts
@@ -245,6 +245,7 @@ export function useOnboardingForm(gdgId: string) {
               learningInterests: parseCsv(form.learningInterests),
               toolsAndTechnologies: parseCsv(form.toolsAndTechnologies),
               otherLinks: parseCsv(form.otherLinks),
+              isOnboarded: true,
               isPublic: form.isPublic,
             },
           },
@@ -330,6 +331,7 @@ export function useOnboardingForm(gdgId: string) {
           params: { gdgId },
           body: {
             data: {
+              isOnboarded: true,
               isPublic: false,
             },
           },

--- a/packages/nexus-api-contracts/src/models/v1/gdgmembers/gdgMember.ts
+++ b/packages/nexus-api-contracts/src/models/v1/gdgmembers/gdgMember.ts
@@ -33,6 +33,7 @@ export const gdgMemberRecord = cz.object({
   learningInterests: cz.array(cz.string()),
   toolsAndTechnologies: cz.array(cz.string()),
   sectionOrder: cz.array(sparkmatesSectionId),
+  isOnboarded: cz.boolean().nullable(),
   isPublic: cz.boolean().nullable(),
 });
 


### PR DESCRIPTION
Closes #813

This pull request introduces a new `isOnboarded` field to the GDG member domain, updating both the backend and frontend to use this field for tracking onboarding status instead of relying on `isPublic`. The main changes ensure that onboarding logic and database schema are consistent and that users are redirected appropriately based on their onboarding status.

**Backend changes:**

- **Domain and Database Schema Updates**
  * Added the `isOnboarded` field to the `GdgMemberProps` type and the Supabase database types, making it available throughout the backend and database schema. [[1]](diffhunk://#diff-ee0b06cb6db13836175f3258988cff53c2a6387bdf0f386e475bf7e771199cbbR84) [[2]](diffhunk://#diff-0d4951c646c441d11e6fac502ed21fd93c889b007d41df75559a7feafe11e427R384) [[3]](diffhunk://#diff-0d4951c646c441d11e6fac502ed21fd93c889b007d41df75559a7feafe11e427R413) [[4]](diffhunk://#diff-0d4951c646c441d11e6fac502ed21fd93c889b007d41df75559a7feafe11e427R442)
  * Updated the `gdgMemberRecord` contract to include the new `isOnboarded` field.

- **Repository Logic**
  * Updated the `SupabaseGdgMemberRepository` to read and write the `isOnboarded` field when mapping between database rows and domain objects. [[1]](diffhunk://#diff-98fd702a93f94cb85dc9f8a48ff8650176a4fa0d72bc02aaa1bc6be975238d2bR53) [[2]](diffhunk://#diff-98fd702a93f94cb85dc9f8a48ff8650176a4fa0d72bc02aaa1bc6be975238d2bR82)

**Frontend changes:**

- **Onboarding Logic**
  * Changed onboarding and authentication logic to use `isOnboarded` instead of `isPublic` for determining whether to redirect users to the onboarding page or their profile. [[1]](diffhunk://#diff-3a53845aa196b07cf793a696f6aa3f864e0ce82eb00505591656db2f232994b2L26-R26) [[2]](diffhunk://#diff-7ccabe409a0f0915b2171a147682f8165d000d91db3d4e6a363bde3e12f5ccb6L30-R30)
  * Ensured that submitting the onboarding form sets `isOnboarded: true` in the backend. [[1]](diffhunk://#diff-3a4cdabf34b1ac1ada91e4cd507bdfff9492ba9e9429cbc1c0783963f2c7015eR248) [[2]](diffhunk://#diff-3a4cdabf34b1ac1ada91e4cd507bdfff9492ba9e9429cbc1c0783963f2c7015eR334)