### PR TITLE
chore: enhance the activation and user experience for the nfc

### DIFF
--- a/apps/nexus-api/src/v1/modules/nfcCards/domain/INfcActivationEventDispatcher.ts
+++ b/apps/nexus-api/src/v1/modules/nfcCards/domain/INfcActivationEventDispatcher.ts
@@ -1,0 +1,3 @@
+export interface INfcActivationEventDispatcher {
+  dispatchActivationSuccess(ownerGdgId: string, cardId: string): Promise<void>;
+}

--- a/apps/nexus-api/src/v1/modules/nfcCards/index.ts
+++ b/apps/nexus-api/src/v1/modules/nfcCards/index.ts
@@ -1,4 +1,5 @@
 import { NfcRepository } from "./infrastructure/NfcRepository";
+import { NfcActivationDispatcher } from "./infrastructure/NfcActivationDispatcher";
 import { NfcCardsModuleController } from "./NfcCardsModuleController";
 import { ActivateByGdgId } from "./useCase/ActivateByGdgId";
 import { ActivateCardUseCase } from "./useCase/ActivateCardUseCase";
@@ -12,8 +13,9 @@ import { ListCardsOfUserUseCase } from "./useCase/ListCardsOfUserUseCase";
 import { SetDestinationUrlUseCase } from "./useCase/SetDestinationUrlUseCase";
 
 const cardRepository = new NfcRepository();
+const activationDispatcher = new NfcActivationDispatcher();
 
-const activateCardUC = new ActivateCardUseCase(cardRepository);
+const activateCardUC = new ActivateCardUseCase(cardRepository, activationDispatcher);
 const createCardBulkUC = new CreateCardsBulkUseCase(cardRepository);
 const createCardUC = new CreateCardUseCase(cardRepository);
 const getCardStatusUC = new GetCardStatusUseCase(cardRepository);
@@ -24,7 +26,7 @@ const setDestinationUrlUC = new SetDestinationUrlUseCase(cardRepository);
 
 const listCardsOfUserUC = new ListCardsOfUserUseCase(cardRepository);
 
-const activatebygdgid = new ActivateByGdgId(cardRepository);
+const activatebygdgid = new ActivateByGdgId(cardRepository, activationDispatcher);
 const getbygdgid = new GetCardByGdgId(cardRepository);
 
 export const nfcCardsModuleController = new NfcCardsModuleController(

--- a/apps/nexus-api/src/v1/modules/nfcCards/infrastructure/NfcActivationDispatcher.ts
+++ b/apps/nexus-api/src/v1/modules/nfcCards/infrastructure/NfcActivationDispatcher.ts
@@ -1,0 +1,27 @@
+import { mailerController } from "@/v1/modules/mailer";
+import { INfcActivationEventDispatcher } from "../domain/INfcActivationEventDispatcher";
+import { gdgMembersController } from "@/v1/modules/members";
+
+export class NfcActivationDispatcher implements INfcActivationEventDispatcher {
+  async dispatchActivationSuccess(
+    ownerGdgId: string,
+    cardId: string,
+  ): Promise<void> {
+    try {
+      const member = await gdgMembersController.findByGdgId(ownerGdgId);
+      if (!member) {
+        throw new Error(`Member with gdgId ${ownerGdgId} not found`);
+      }
+
+      await mailerController.sendEmail(
+        member.email,
+        "Your Nexus Card is Activated! 🎉",
+        `Hi ${member.firstName},\n\nYour physical Nexus Card (${cardId}) has been successfully activated and permanently linked to your digital identity.\n\nYou can now tap your card to share your Sparkmates profile at any event!`,
+      );
+
+      console.log(`[NfcActivationDispatcher] Successfully dispatched activation email to ${member.email}`);
+    } catch (error) {
+       console.error(`[NfcActivationDispatcher] Failed to dispatch email for ${ownerGdgId}:`, error);
+    }
+  }
+}

--- a/apps/nexus-api/src/v1/modules/nfcCards/useCase/ActivateByGdgId.ts
+++ b/apps/nexus-api/src/v1/modules/nfcCards/useCase/ActivateByGdgId.ts
@@ -1,9 +1,11 @@
 import { INfcRepository } from "../domain/INfcRepository";
-
- 
+import { INfcActivationEventDispatcher } from "../domain/INfcActivationEventDispatcher";
 
 export class ActivateByGdgId {
-  constructor(private readonly repository: INfcRepository) {}
+  constructor(
+    private readonly repository: INfcRepository,
+    private readonly dispatcher?: INfcActivationEventDispatcher
+  ) {}
 
   async execute(gdgId: string, actorGdgId: string) {
     const card = await this.repository.findByGdgid(gdgId);
@@ -17,7 +19,11 @@ export class ActivateByGdgId {
     }
 
     card.activate();
-      await this.repository.persistUpdates(card);
+    await this.repository.persistUpdates(card);
+
+    if (this.dispatcher) {
+      this.dispatcher.dispatchActivationSuccess(actorGdgId, card.props.id).catch(console.error);
+    }
 
     return card;
   }

--- a/apps/nexus-api/src/v1/modules/nfcCards/useCase/ActivateCardUseCase.ts
+++ b/apps/nexus-api/src/v1/modules/nfcCards/useCase/ActivateCardUseCase.ts
@@ -1,9 +1,11 @@
 import { INfcRepository } from "../domain/INfcRepository";
-
- 
+import { INfcActivationEventDispatcher } from "../domain/INfcActivationEventDispatcher";
 
 export class ActivateCardUseCase {
-  constructor(private readonly repository: INfcRepository) {}
+  constructor(
+    private readonly repository: INfcRepository,
+    private readonly dispatcher?: INfcActivationEventDispatcher
+  ) {}
 
   async execute(cardId: string, actorGdgId: string) {
     const card = await this.repository.findById(cardId);
@@ -13,7 +15,12 @@ export class ActivateCardUseCase {
     }
 
     card.activate();
-      await this.repository.persistUpdates(card);
+    await this.repository.persistUpdates(card);
+
+    if (this.dispatcher) {
+      // Do not await to prevent blocking the HTTP response
+      this.dispatcher.dispatchActivationSuccess(actorGdgId, cardId).catch(console.error);
+    }
 
     return card;
   }

--- a/apps/nexus-web/src/app/sparkmates/[gdgId]/page.tsx
+++ b/apps/nexus-web/src/app/sparkmates/[gdgId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import React from "react";
+import { useSearchParams } from "next/navigation";
 import {
   SparkmatesPortfolio,
   type SparkmatesSource,
@@ -27,24 +27,20 @@ export default function SparkmatesPage({
   const { gdgId } = React.use(params);
   const searchParams = useSearchParams();
   const source = normalizeSource(searchParams.get("source"));
-  const router = useRouter();
 
   const { data, isLoading, isError, error } = useNfcCard(gdgId);
 
   const notactivated =
     source === "nfc_card" && data && data.status !== "activated";
 
-  useEffect(() => {
-    if (notactivated) {
-      router.push(
-        `/nfc-cards/${data.id}/activate?redirect=/sparkmates/${gdgId}`,
-      );
-    }
-  }, [data, source]);
-
   if (isLoading) return <ProfileLoadingState />;
 
-  if (notactivated) return <ProfileLoadingState />;
-
-  return <ProfilePublicView gdgId={gdgId} source={source} />;
+  return (
+    <ProfilePublicView
+      gdgId={gdgId}
+      source={source}
+      nfcCard={data ?? null}
+      isNfcActivationRequired={!!notactivated}
+    />
+  );
 }

--- a/apps/nexus-web/src/features/authentication/components/RequireUnauthenticated.tsx
+++ b/apps/nexus-web/src/features/authentication/components/RequireUnauthenticated.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter, usePathname } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { LINKS } from "@/lib/constants/links";
 import { LoadingScreen } from "@/components/shared";
 import { STATUS, useAuthContext } from "../store/useAuthStore";
@@ -13,6 +13,7 @@ export const RequireUnauthenticated = ({
 }) => {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { status, memberProfile } = useAuthContext();
 
   useEffect(() => {
@@ -26,12 +27,17 @@ export const RequireUnauthenticated = ({
         return;
       }
 
-      // Already onboarded, redirect away from auth pages to their profile
+      // Already onboarded, redirect away from auth pages
       if (pathname !== LINKS.onboarding) {
-        router.push(LINKS.sparkmates_me);
+        const next = searchParams.get("next");
+        if (next && next.startsWith("/")) {
+          router.push(next);
+        } else {
+          router.push(LINKS.sparkmates_me);
+        }
       }
     }
-  }, [status, memberProfile, pathname, router]);
+  }, [status, memberProfile, pathname, router, searchParams]);
 
   if (status === STATUS.AUTHENTICATED || status === STATUS.CHECKING) {
     const message =

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { motion, useInView } from "motion/react";
 import {
   Avatar,
@@ -11,8 +11,12 @@ import {
   ShineBorder,
   Text,
 } from "@packages/spark-ui";
+import { toast } from "react-toastify";
 import { CosmosParticles, LoadingScreen } from "@/components/shared";
 import { ASSETS } from "@/lib/constants/assets";
+import { useAuthContext } from "@/features/authentication/store/useAuthStore";
+import { useCardActivation } from "@/features/nfc-cards/hooks/useActivateCardMutation";
+import { useQueryClient } from "@tanstack/react-query";
 import { SparkmatesSource, useSparkmateProfile, useSuggestedSparkmates } from "../.."; 
 import { PublicSkillsAndLinksSection } from "./components/PublicSkillsAndLinksSection";
 import { ComingSoonPlaceholder } from "../ComingSoonPlaceholder";
@@ -178,11 +182,19 @@ const SPARK_BADGE = {
 export function ProfilePublicView({
   gdgId,
   source,
+  nfcCard,
+  isNfcActivationRequired,
 }: {
   gdgId: string;
   source: SparkmatesSource;
+  nfcCard?: any;
+  isNfcActivationRequired?: boolean;
 }) {
   const [search, setSearch] = useState("");
+  const [activationSuccess, setActivationSuccess] = useState(false);
+  const { decodedToken, status: authStatus } = useAuthContext();
+  const activateCardMutation = useCardActivation();
+  const queryClient = useQueryClient();
 
   const {
     data: profile,
@@ -231,41 +243,149 @@ export function ProfilePublicView({
     );
   }
 
-  // const requiresActivation = profile.source === "nfc_card";
-  // const showActivationGate =
-    // requiresActivation && profile.status !== "activated";
+  if (isNfcActivationRequired && nfcCard && !activationSuccess) {
+    const isOwner = decodedToken?.memberInfo.gdgId === gdgId;
 
-  // if (showActivationGate) {
-  //   return (
-  //     <div className="min-h-screen bg-[#010B1D] px-6 pb-24 pt-40 text-white">
-  //       <div className="mx-auto max-w-2xl rounded-3xl border border-white/15 bg-white/5 p-8 text-center">
-  //         <Text variant="heading-5" className="text-white">
-  //           Sparkmates Profile Not Active
-  //         </Text>
-  //         <Text variant="body" className="mt-2 text-[#C1C7CD]">
-  //           This digital portfolio is not activated yet.
-  //         </Text>
-  //         {/* {isOwner ? (
-  //           <Button
-  //             variant="colored"
-  //             subVariant="blue"
-  //             size="lg"
-  //             className="mt-6 w-full"
-  //             disabled={activateMutation.isPending}
-  //             onClick={() => {
-  //               if (!token) return;
-  //               activateMutation.mutate(token);
-  //             }}
-  //           >
-  //             {activateMutation.isPending
-  //               ? "Activating..."
-  //               : "Activate Sparkmates Profile"}
-  //           </Button>
-  //         ) : null} */}
-  //       </div>
-  //     </div>
-  //   );
-  // }
+    return (
+      <CosmosParticles
+        particleColors={["#ffffff", "#4285f4"]}
+        particleCount={180}
+        particleSpread={14}
+        speed={0.028}
+        particleBaseSize={75}
+        moveParticlesOnHover
+        alphaParticles={true}
+        className="min-h-screen bg-[#010B1D] bg-[radial-gradient(circle_at_30%_55%,rgba(66,133,244,0.2),transparent_30%),radial-gradient(circle_at_58%_73%,rgba(249,171,0,0.14),transparent_25%)] flex items-center justify-center p-4 w-full text-white"
+      >
+        <div className="relative z-10 w-full max-w-lg bg-zinc-900/50 backdrop-blur-xl border border-white/10 rounded-3xl p-8 shadow-2xl">
+          <div className="text-center mb-8">
+            <div className="mx-auto w-16 h-16 bg-gradient-to-tr from-[#FB2C36] to-[#2B7FFF] rounded-2xl flex items-center justify-center shadow-lg shadow-blue-500/20 mb-6">
+              <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <Text variant="heading-5" className="text-white">
+              Activate Nexus Card
+            </Text>
+            <Text variant="body-sm" className="text-zinc-400 mt-2 font-mono">
+              {nfcCard.id}
+            </Text>
+          </div>
+
+          {authStatus === "checking" ? (
+            <div className="py-8"><LoadingScreen fullPage={false} message="Checking authentication..." /></div>
+          ) : !decodedToken ? (
+            <div className="space-y-4">
+              <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-2xl p-5 text-center">
+                <Text variant="body-sm" className="text-yellow-200">
+                  This digital portfolio is not activated yet. Log in to your account if this is your card to link it!
+                </Text>
+              </div>
+              <Button
+                variant="colored"
+                subVariant="blue"
+                size="lg"
+                className="w-full text-white font-semibold"
+                onClick={() => {
+                  const currentPath = window.location.pathname + window.location.search;
+                  window.location.href = `/signin?next=${encodeURIComponent(currentPath)}`;
+                }}
+              >
+                Log In to Link Card
+              </Button>
+            </div>
+          ) : !isOwner ? (
+            <div className="bg-red-500/10 border border-red-500/20 rounded-2xl p-5 text-center">
+               <Text variant="body-sm" className="text-red-200">
+                You are not the owner of this card. You cannot activate it.
+               </Text>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="bg-white/5 border border-white/10 rounded-2xl p-4 flex items-center gap-4">
+                <GradientProfilePicture
+                  size="sm"
+                  src={decodedToken.memberInfo.avatarUrl || ASSETS.AUTH.AVATAR_DEFAULT}
+                  alt={decodedToken.memberInfo.firstName}
+                  fallback={decodedToken.memberInfo.firstName.charAt(0)}
+                />
+                <div className="flex-1 min-w-0">
+                  <Text variant="body-sm" className="text-[#C1C7CD]">Activating as</Text>
+                  <Text variant="body-lg" weight="bold" className="text-white truncate">
+                    {decodedToken.memberInfo.firstName} {decodedToken.memberInfo.lastName}
+                  </Text>
+                </div>
+              </div>
+
+              <Button
+                variant="colored"
+                subVariant="blue"
+                size="lg"
+                className="w-full"
+                disabled={activateCardMutation.isPending}
+                onClick={() => {
+                  activateCardMutation.mutate(nfcCard.id, {
+                    onSuccess: () => {
+                      toast.success("Card activated successfully!");
+                      setActivationSuccess(true);
+                      // Provide an initial invalidate but without letting it destroy the gate yet
+                      queryClient.invalidateQueries({ queryKey: ["sparkmates-profile", gdgId] });
+                      queryClient.invalidateQueries({ queryKey: ["nfc-card", gdgId] });
+                    },
+                    onError: (err: any) => {
+                      toast.error(err.message || "Failed to activate card");
+                    }
+                  });
+                }}
+              >
+                {activateCardMutation.isPending ? "Activating..." : "Confirm Activation"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </CosmosParticles>
+    );
+  }
+
+  if (activationSuccess) {
+    return (
+      <CosmosParticles
+        particleColors={["#ffffff", "#4285f4"]}
+        particleCount={180}
+        particleSpread={14}
+        speed={0.028}
+        particleBaseSize={75}
+        moveParticlesOnHover
+        alphaParticles={true}
+        className="min-h-screen bg-[#010B1D] bg-[radial-gradient(circle_at_30%_55%,rgba(66,133,244,0.2),transparent_30%),radial-gradient(circle_at_58%_73%,rgba(249,171,0,0.14),transparent_25%)] flex items-center justify-center p-4 w-full text-white"
+      >
+        <div className="relative z-10 w-full max-w-lg bg-zinc-900/50 backdrop-blur-xl border border-[#00C950]/30 rounded-3xl p-8 shadow-2xl text-center">
+          <div className="mx-auto w-20 h-20 bg-gradient-to-tr from-[#00C950] to-[#2B7FFF] rounded-full flex items-center justify-center shadow-lg shadow-[#00C950]/30 mb-6">
+            <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <Text variant="heading-4" weight="bold" className="text-white mb-4">
+            Link Successful!
+          </Text>
+          <Text variant="body" className="text-zinc-300 mb-8 max-w-sm mx-auto">
+            Your physical Nexus Card is now officially active and linked to your digital identity. You will also receive a confirmation email shortly.
+          </Text>
+          <Button
+            variant="colored"
+            subVariant="blue"
+            size="lg"
+            className="w-full text-white font-bold"
+            onClick={() => {
+              setActivationSuccess(false);
+            }}
+          >
+            Explore My Public Profile
+          </Button>
+        </div>
+      </CosmosParticles>
+    );
+  }
 
 
 

--- a/docs/NFC/01-IDENTITY_FLOW.md
+++ b/docs/NFC/01-IDENTITY_FLOW.md
@@ -14,15 +14,15 @@ graph TD
     %% Context A: Public Networking
     subgraph "Scenario A: Networking (Public)"
         UserPhone["Friend's Phone"]
-        Browser["Mobile Browser <br/> (Opens /tap/crd_123)"]
-        IdentityAPI["Identity API <br/> (GET /cards/:id/status)"]
-        PortfolioUI["Show Portfolio <br/> (Redirects to /id/user)"]
+        Browser["Mobile Browser <br/> (Opens /sparkmates/:gdgId?source=nfc_card)"]
+        NexusAPI["Nexus API <br/> (GET /api/v1/nfc-cards/:cardId/status)"]
+        PortfolioUI["Show Portfolio <br/> (Redirects to /sparkmates/:gdgId)"]
     end
 
     %% Context B: Event Check-in
     subgraph "Scenario B: Event Attendance (Admin)"
         AdminDevice["Organizer's Scanner <br/> (Admin App)"]
-        EventAPI["Event API <br/> (POST /api/event-system/checkin)"]
+        EventAPI["Nexus API (Events) <br/> (POST /api/v1/events/checkin)"]
         AttendanceDB[("Attendance DB")]
         SuccessMsg["User Checked In!"]
     end
@@ -30,8 +30,8 @@ graph TD
     %% Flow
     Card -->|User Taps Phone| UserPhone
     UserPhone -->|Opens URL| Browser
-    Browser --> IdentityAPI
-    IdentityAPI --> PortfolioUI
+    Browser --> NexusAPI
+    NexusAPI --> PortfolioUI
 
     Card -->|Organizer Scans| AdminDevice
     AdminDevice -->|Sends UUID + EventID| EventAPI
@@ -44,29 +44,29 @@ graph TD
 ## 2. Scenario A: Public Profile (The "Linktree")
 
 - **Context:** A user meets someone new and lets them tap their card.
-- **Trigger:** Phone opens `https://gdg-pup.com/tap/:card_uid`.
-- **Redirect Logic:** Website checks card status -> Redirects to Profile (e.g., `/id/janedoe`).
-- **API Used:** `GET /api/identity/cards/:card_uid/status`
+- **Trigger:** Phone opens `https://gdgpup.org/sparkmates/:gdgId?source=nfc_card`.
+- **Logic:** Website loads the user's public Sparkmates profile.
+- **API Used:** `GET /api/v1/nfc-cards/:cardId/status`
 
 ### Profile Payload (JSON)
 
 The endpoint returns aggregated data for the "Linktree" view.
 
 ```json
-// GET /api/identity/users/:handle
+// GET /api/v1/gdgmembers/:gdgId
 {
   "status": "success",
   "data": {
     "user": {
       "name": "Jane Doe",
-      "avatar_url": "https://...",
+      "avatarUrl": "https://...",
       "role": "MEMBER"
     },
     "profile": {
       "bio": "Full Stack Dev @ GDG",
-      "github": "https://github.com/jane",
-      "linkedin": "https://linkedin.com/in/jane",
-      "portfolio": "https://janedoe.dev"
+      "githubUrl": "https://github.com/jane",
+      "linkedinUrl": "https://linkedin.com/in/jane",
+      "portfolioUrl": "https://janedoe.dev"
     }
   }
 }
@@ -78,7 +78,7 @@ The endpoint returns aggregated data for the "Linktree" view.
 
 - **Context:** An attendee arrives at a GDG event. The organizer is holding a phone/scanner running the **Admin App**.
 - **Trigger:** The organizer actively scans the card's UUID into the attendance system.
-- **Endpoint:** `POST /api/event-system/checkin`
+- **Endpoint:** `POST /api/v1/events/checkin`
 
 ### Attendance Sequence Diagram
 
@@ -86,7 +86,7 @@ The endpoint returns aggregated data for the "Linktree" view.
 sequenceDiagram
     participant Organizer as 👮 Organizer (Admin App)
     participant Card as 💳 Attendee Card
-    participant API as 📅 Event API
+    participant API as 📅 Nexus API (Events)
     participant DB as 🗄️ Database
 
     Note over Organizer: Event: "Tech Talk 2025"
@@ -114,7 +114,7 @@ sequenceDiagram
 When the Admin App scans the card, it sends this JSON to the server:
 
 ```json
-// POST /api/event-system/checkin
+// POST /api/v1/events/checkin
 {
   "data": {
     "eventId": "evt_abc12345", // Selected by Organizer

--- a/docs/NFC/02-ENCODING_GUIDE.md
+++ b/docs/NFC/02-ENCODING_GUIDE.md
@@ -6,8 +6,8 @@ This document outlines the technical methods for "burning" (encoding) our system
 
 Every card must hold a unique URL record (NDEF Record).
 
-- **Format:** `https://gdg-pup.com/tap/[CARD_UUID]`
-- **Purpose:** A neutral entry point that redirects to either **Activation** (if new) or **Profile** (if owned).
+- **Format:** `https://gdgpup.org/sparkmates/[GDG_ID]?source=nfc_card`
+- **Purpose:** A direct entry point to the assigned member's public Sparkmates profile.
 
 ---
 
@@ -40,7 +40,7 @@ This method outsources the work to the card printing vendor.
 
 1.  **Generate Excel Sheet:** Create a spreadsheet with:
     - `PRINT_ID`: The human-readable ID (e.g., GDG-001).
-    - `NFC_URL`: The specific payload (e.g., gdg-pup.com/activate/...).
+    - `NFC_URL`: The specific payload (e.g., https://gdgpup.org/sparkmates/usr_123?source=nfc_card).
 2.  **Send to Vendor:** Email this file along with the artwork.
 3.  **Receive:** The vendor ships boxes of cards that are already programmed.
 
@@ -54,14 +54,14 @@ It is critical that every physical card corresponds to a row in our database. Du
 
 Before you write to the physical cards, your database table must be populated like this:
 
-| card_id (UUID) | user_id (FK) | is_activated | status  |
-| :------------- | :----------- | :----------- | :------ |
-| `a1b2-c3d4...` | **`NULL`**   | **`FALSE`**  | `READY` |
-| `e5f6-g7h8...` | **`NULL`**   | **`FALSE`**  | `READY` |
+| card_id (UUID) | gdg_id (FK) | status  | activated_at |
+| :------------- | :----------- | :------ | :----------- |
+| `a1b2-c3d4...` | **`usr_12`** | `issued`| `NULL`       |
+| `e5f6-g7h8...` | **`usr_34`** | `issued`| `NULL`       |
 
-- **uuid:** The unique ID burned into the card.
-- **user_id:** Must be **NULL**. The card is unowned.
-- **is_activated:** Must be **FALSE**.
+- **id:** The unique UUID burned into the card.
+- **gdg_id:** Must be pre-assigned to a valid member.
+- **status:** Must be exactly `"issued"`.
 
 ### Generation Script (Node.js Example)
 
@@ -81,7 +81,7 @@ import fs from "fs";
 const supabase = createClient("YOUR_SUPABASE_URL", "YOUR_SERVICE_ROLE_KEY");
 
 const BATCH_SIZE = 100; // How many cards are we making?
-const BASE_URL = "https://gdg-pup.com/tap";
+const BASE_URL = "https://gdgpup.org/sparkmates";
 
 let csvContent = "NFC_URL\n";
 const dbRecords = [];
@@ -91,17 +91,20 @@ console.log(`Generating ${BATCH_SIZE} unique cards...`);
 for (let i = 0; i < BATCH_SIZE; i++) {
   const id = uuidv4(); // Generate ID here, not in DB
 
+  const gdgId = `usr_${Math.floor(Math.random() * 90000) + 10000}`; // Example GDG ID logic
+
   // 1. For the Physical Card (CSV)
-  const fullUrl = `${BASE_URL}/${id}`;
+  const fullUrl = `${BASE_URL}/${gdgId}?source=nfc_card`;
   csvContent += `${fullUrl}\n`;
 
   // 2. For the Database (Pre-Fill)
-  // We explicitly set the 'id' here to match the CSV
+  // We explicitly set the 'id' here to formally register the minted UUID
+  // NOTE: In production, gdg_id MUST be assigned correctly to target users
   dbRecords.push({
     id: id,
-    user_id: null, // No owner yet
-    is_activated: false, // Waiting for user
-    status: "READY",
+    gdg_id: gdgId, // Must link to actual member's GDG ID
+    status: "issued", // Ready for activation verification
+    activated_at: null
   });
 }
 

--- a/docs/NFC/03-PROVISIONING.md
+++ b/docs/NFC/03-PROVISIONING.md
@@ -1,61 +1,50 @@
-# 📦 NFC Card Distribution & Self-Activation
+# 📦 NFC Card Distribution & Activation
 
-This document outlines the operational workflow for distributing NFC cards. We utilize a **Self-Service Activation** model, meaning cards are distributed "blank" (pre-programmed but unlinked) and users activate them personally.
+This document outlines the operational workflow for distributing NFC cards. We utilize a **Pre-Assigned Activation** model, meaning cards are linked to a specific user *before* or *during* distribution, and the user must explicitly "activate" the card to verify possession before it can be used.
 
-## 1. The Strategy: "Unboxing" Experience
+## 1. The Strategy: "Pre-Assigned" Model
 
-We moved away from the Admin-led provisioning. Now, the user is in control.
-
-- **Speed:** No long lines at the help desk. Just hand out the cards like swag.
-- **Engagement:** The user gets a magical "first tap" experience on their own device.
-- **Scalability:** We can distribute 1,000+ cards in minutes.
+- **Security:** Cards are explicitly linked to a user (`gdgId`) upon physical creation/distribution. If someone steals a card, they cannot claim it or use it, because the backend explicitly ties the physical card UUID to a single user.
+- **Verification:** The user must natively log in to the platform and authorize the activation to prove they physically received the exact card assigned to them.
+- **Status Machine:** Cards strictly progress through statuses: `"issued"` ➡️ `"activated"` ➡️ `"suspended"`/`"revoked"`.
 
 ---
 
 ## 2. The Distribution Workflow 🤝
 
-### Step 1: Handout
+### Step 1: Assignment
+- **System:** Administrators bulk-generate NFC cards using the `CreateCardsBulkUseCase` or individually via `CreateCardUseCase`.
+- **Database:** Cards are inserted into the `nfc_cards` table with:
+  - `id`: The UUID burned into the card.
+  - `gdg_id`: The ID of the specific member receiving the card.
+  - `status`: Strictly set to `"issued"`.
+  - `activated_at`: `NULL`.
 
-- **Venue:** Check-in desk or Swag bag.
-- **Action:** Volunteer hands a card to the member.
-- **Validation:** Ideally verify they are a registered attendee, but technically **it doesn't matter** if a non-member gets a card, because they cannot activate it without a valid GDG Account login.
+### Step 2: Handout
+- **Action:** An administrator or volunteer physically hands the pre-assigned card to the correct member.
 
 ---
 
-## 3. The Activation Workflow (User Journey) �
+## 3. The Activation Workflow (User Journey)
 
-This happens on the user's phone, at their own pace.
+This happens on the user's device to securely formalize their possession of the card.
 
-### Step 1: The Magic Tap
+### Step 1: The Trigger
+- **Action:** The user logs into the Nexus Platform.
+- **Action:** The user taps the card on their phone (which hits an intercept endpoint) OR actively clicks an "Activate Card" button within their Sparkmates setting dashboard.
 
-User taps their new card on their phone.
+### Step 2: Authorization Check
+- **API Call:** The frontend sends a request to `POST .../useCase/ActivateCardUseCase` (if activated by card UUID) or `ActivateByGdgId` (if automatically inferred from their session).
+- **Validation Engine:** 
+  1. The backend compares requesting user's ID against the card's `ownerGdgId`. If they do not match, it instantly throws an `Unauthorized: Only the card owner can activate the card` error.
+  2. The backend checks the card's domain `status`. It must be exactly `"issued"` to proceed. Doing this on an already active card throws an error.
 
-- **Card Payload:** `https://gdg-pup.com/tap/crd_123`
-- **Result:** Phone opens browser. The page checks `GET /api/identity/cards/crd_123/status`.
-
-### Step 2: System Check
-
-The system checks the `nfc_cards` database table for ID `a1b2-c3d4...`.
-
-- **Condition:** Is `user_id` NULL?
-  - **YES:** Show **Activation Screen**.
-  - **NO:** Show **Public Profile** (Already owned).
-
-### Step 3: Authentication
-
-- **Screen:** "Welcome! Please login to claim this card."
-- **Action:** User logs in with their GDG / Google Account.
-
-### Step 4: Confirmation
-
-- **Screen:** "Do you want to link this card to **[Jane Doe]**?"
-- **Action:** User clicks **"Start My Portfolio"**.
-
-### Step 5: Success
-
-- **System:** Updates database -> Sets `user_id` to Jane's ID.
-- **UI:** Redirects immediately to Jane's new Public Profile.
-- **Result:** The card is now permanently hers.
+### Step 3: Success & Persistence
+- **Mutation:** The core domain entity `NfcCard` fires `.activate()`, changing internal state securely.
+- **Database Updates:** The `NfcRepository` executes `persistUpdates(card)` directly to the `nfc_cards` row:
+  - `status` updates to `"activated"`.
+  - `activated_at` receives a fresh ISO 8601 timestamp.
+- **Result:** The card is officially live! It can now be used smoothly at check-in events and public scans.
 
 ---
 
@@ -63,54 +52,28 @@ The system checks the `nfc_cards` database table for ID `a1b2-c3d4...`.
 
 ```mermaid
 sequenceDiagram
-    participant User as User
-    participant Card as New Card
-    participant App as Web App (Activation)
-    participant API as Identity API
+    participant Admin as Organizer
     participant DB as Database
+    participant User as User
+    participant Card as NFC Card
+    participant App as Web App
+    participant API as Nexus API
 
-    User->>Card: Taps Card (First Time)
-    Card-->>User: Opens /tap/xyz-123
-    User->>App: Browser Loads "Traffic Cop" Page
+    Note over Admin,DB: Phase 1: Card Provisioning (Issued)
+    Admin->>API: Bulk Register Cards (Assigns UUIDs to GDG IDs)
+    API->>DB: INSERT nfc_cards (status: 'issued', gdg_id: '123')
+    Admin->>User: Hands physical card to User
 
-    App->>API: GET /cards/xyz-123/status
-    API->>DB: Is this card linked?
-    DB-->>API: No (user_id is NULL)
-    API-->>App: { status: "READY" }
-    App->>User: Redirects to /activate/xyz-123
-
-    App->>User: Prompts Login
-    User->>App: Logs In & Clicks "Activate"
-
-    App->>API: POST /api/identity/cards/activate { cardId: xyz-123 }
-
-    API->>DB: UDPATE nfc_cards SET user_id = CURRENT_USER
-    DB-->>API: Success
-
+    Note over User,API: Phase 2: User Activation (Activated)
+    User->>App: Logs in & triggers Activation
+    App->>API: POST /api/v1/nfc/activate
+    API->>DB: Fetch Card
+    DB-->>API: Returns Card Entity
+    
+    Note right of API: Security Check:<br/>1. Is Current User == ownerGdgId?<br/>2. Is status == "issued"?
+    
+    API->>DB: UPDATE nfc_cards SET status='activated', activated_at=NOW()
+    DB-->>API: Success Response
     API-->>App: 200 OK
-    App->>User: Redirects to /id/xyz-123 (Profile)
+    App->>User: "Card Activated Successfully!"
 ```
-
----
-
-## 5. Handling Issues
-
-### "This card is already active!"
-
-If a user taps a card that belongs to someone else:
-
-- **Screen:** "This card belongs to **[John Smith]**."
-- **Action:** User cannot claim it.
-
-### "Card Not Found"
-
-If a user taps a card that wasn't in our CSV/Database:
-
-- **Screen:** "Invalid Card. Please return to the help desk."
-- **Reason:** The card might be damaged or was missed during the Encoding Phase.
-
-### Lost Cards
-
-The user can login to their dashboard and click **"Deactivate Card"**.
-
-- This sets `nfc_cards.status` to `LOST` and unlinks it so no one else can scan it.


### PR DESCRIPTION
This pull request introduces a comprehensive NFC card activation flow, including both backend and frontend changes to support self-service card activation, user feedback, and notification emails. The main improvements are the implementation of an activation event dispatcher, integration of activation logic in the UI, and updates to documentation to reflect the new flow.

**Backend: NFC Card Activation Event Dispatching**

- Added an `INfcActivationEventDispatcher` interface and implemented it with `NfcActivationDispatcher`, which sends activation confirmation emails to users upon successful card activation. [[1]](diffhunk://#diff-802c1df8d4d42a723ef541e93d8c27ca7aea6dd5fbdd4696f1d58fd32f6cd7cbR1-R3) [[2]](diffhunk://#diff-97fcb5955b9225d938ac9e27c8286f74b7dfd760e9db63edb7781a51690dd05aR1-R27)
- Updated the `ActivateCardUseCase` and `ActivateByGdgId` use cases to accept an event dispatcher and trigger the dispatch after activation. [[1]](diffhunk://#diff-d295c6790065d4668bf5c696737ebd80326d9d30cd35edc670ec3074fc66919bL2-R8) [[2]](diffhunk://#diff-d295c6790065d4668bf5c696737ebd80326d9d30cd35edc670ec3074fc66919bR20-R24) [[3]](diffhunk://#diff-70df6b328c3e60c480145b69a86f3861fd4e018bd36f1f5415553798af076a47L2-R8) [[4]](diffhunk://#diff-70df6b328c3e60c480145b69a86f3861fd4e018bd36f1f5415553798af076a47R24-R27)
- Registered the dispatcher in the module setup and injected it into relevant use cases. [[1]](diffhunk://#diff-031161708e49a8caa3a574412fba5f0d80090cfcc463f21615c3df50effa41c0R2) [[2]](diffhunk://#diff-031161708e49a8caa3a574412fba5f0d80090cfcc463f21615c3df50effa41c0R16-R18) [[3]](diffhunk://#diff-031161708e49a8caa3a574412fba5f0d80090cfcc463f21615c3df50effa41c0L27-R29)

**Frontend: Self-Service NFC Card Activation UI**

- Refactored the Sparkmates public profile page to show an activation gate when a card is not yet activated, allowing the owner to log in and activate their card directly. Displays success feedback and disables profile viewing until activation is complete. ([apps/nexus-web/src/app/sparkmates/[gdgId]/page.tsxL3-R4](diffhunk://#diff-829b5491ee6aa009dbda6f8eb40ca18ffb4352f6b633068f23049dca83bf016fL3-R4), [apps/nexus-web/src/app/sparkmates/[gdgId]/page.tsxL30-R45](diffhunk://#diff-829b5491ee6aa009dbda6f8eb40ca18ffb4352f6b633068f23049dca83bf016fL30-R45), [[1]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R14-R19) [[2]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R185-R197) [[3]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L234-R388)
- The activation flow includes authentication checks, error handling, and success toasts for improved UX. [[1]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R14-R19) [[2]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R185-R197) [[3]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L234-R388)

**Frontend: Authentication Redirect Improvements**

- Enhanced the unauthenticated route guard to support a `next` parameter, allowing users to be redirected back to their intended page after login. [[1]](diffhunk://#diff-1f5d70feb51cb3a0dc4e71a36e03446c746748c583710665364e95ed01b98b69L4-R4) [[2]](diffhunk://#diff-1f5d70feb51cb3a0dc4e71a36e03446c746748c583710665364e95ed01b98b69R16) [[3]](diffhunk://#diff-1f5d70feb51cb3a0dc4e71a36e03446c746748c583710665364e95ed01b98b69L29-R40)

**Documentation**

- Updated the NFC identity flow diagram to match the new API endpoints and redirect logic for card activation and portfolio display.

Closes #816