### PR TITLE
refactor(nexus-web): sparkmates custom button star functionality

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/CustomButtonsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/CustomButtonsSection.tsx
@@ -1,6 +1,6 @@
-import { Button, ShineBorder, Text, Modal, Input } from "@packages/spark-ui";
+import { Button, Text, Modal, Input } from "@packages/spark-ui";
 import { profile } from "console";
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Divider } from "../components/Divider";
 import { ProjectCard } from "../components/ProjectCard";
 import { addIcon } from "../icons/addIcon";
@@ -10,24 +10,40 @@ import { getLinkHostname } from "../utils/getLinkHostname";
 import { ProjectsSection } from "./ProjectsSection";
 import { ImpactSection } from "./ImpactSection";
 import { BadgesSection } from "./BadgesSection";
+import {
+  parseCustomButtonLinks,
+  serializeCustomButtonLinks,
+} from "../../../utils/customButtonFavorites";
 
 export const CustomButtonsSection = ({ profile }: { profile: UserProfile }) => {
-  const [starredCustomButtons, setStarredCustomButtons] = useState<Set<number>>(
-    () => new Set([0]),
+  const parsedProfileLinks = useMemo(
+    () => parseCustomButtonLinks(profile.otherLinks),
+    [profile.otherLinks],
   );
   const { mutate: updateProfile, isPending } = useUpdateSparkmateProfile(profile.gdgId);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [links, setLinks] = useState<string[]>(profile.otherLinks || []);
+  const [links, setLinks] = useState<string[]>(parsedProfileLinks.links);
+  const [starredCustomButtons, setStarredCustomButtons] = useState<Set<string>>(
+    () => new Set(parsedProfileLinks.starredUrls),
+  );
   const [newLink, setNewLink] = useState("");
 
-  const toggleStar = (index: number) => {
+  useEffect(() => {
+    setLinks(parsedProfileLinks.links);
+    setStarredCustomButtons(new Set(parsedProfileLinks.starredUrls));
+  }, [parsedProfileLinks]);
+
+  const toggleStar = (url: string) => {
     setStarredCustomButtons((prev) => {
       const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
+      if (next.has(url)) {
+        next.delete(url);
       } else {
-        next.add(index);
+        next.add(url);
       }
+
+      updateProfile({ otherLinks: serializeCustomButtonLinks(links, next) });
+
       return next;
     });
   };
@@ -40,18 +56,24 @@ export const CustomButtonsSection = ({ profile }: { profile: UserProfile }) => {
   };
 
   const handleRemoveLink = (index: number) => {
+    const removedLink = links[index];
     setLinks(links.filter((_, i) => i !== index));
+    setStarredCustomButtons((prev) => {
+      const next = new Set(prev);
+      next.delete(removedLink);
+      return next;
+    });
   };
 
   const handleSave = () => {
-    updateProfile({ otherLinks: links }, {
+    updateProfile({ otherLinks: serializeCustomButtonLinks(links, starredCustomButtons) }, {
       onSuccess: () => {
         setIsEditModalOpen(false);
       },
     });
   };
 
-  const customLinks = (profile.otherLinks ?? []).map((url) => ({
+  const customLinks = links.map((url) => ({
     title: getLinkHostname(url),
     url,
   }));
@@ -80,18 +102,12 @@ export const CustomButtonsSection = ({ profile }: { profile: UserProfile }) => {
           {customLinks.map((item, index) => (
             <div
               key={`${item.title}-${index}`}
-              className="relative overflow-hidden rounded-2xl border border-white/20 bg-[rgba(255,255,255,0.05)] p-5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)] transition-[border-color,box-shadow] duration-300"
+              className={`relative overflow-hidden rounded-2xl p-5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)] transition-[box-shadow,background] duration-300 ${
+                starredCustomButtons.has(item.url)
+                  ? "rainbow-border bg-[linear-gradient(90deg,#0F2449_0%,#2A4F91_50%,#0F2449_100%)]"
+                  : "border border-white/20 bg-[rgba(255,255,255,0.05)]"
+              }`}
             >
-              <ShineBorder
-                borderWidth={1.25}
-                duration={9}
-                shineColor={["#FB2C36", "#F0B100", "#00C950", "#2B7FFF"]}
-                className={
-                  starredCustomButtons.has(index)
-                    ? "opacity-100 transition-opacity duration-300"
-                    : "opacity-0 transition-opacity duration-300"
-                }
-              />
               <div className="flex items-start justify-between min-w-0">
                 <div className="min-w-0 flex-1">
                   <Text
@@ -109,9 +125,9 @@ export const CustomButtonsSection = ({ profile }: { profile: UserProfile }) => {
                   variant="ghost"
                   size="sm"
                   className="h-8 w-8 p-0 text-white shrink-0"
-                  onClick={() => toggleStar(index)}
+                  onClick={() => toggleStar(item.url)}
                 >
-                  {starredCustomButtons.has(index) ? "★" : "☆"}
+                  {starredCustomButtons.has(item.url) ? "★" : "☆"}
                 </Button>
               </div>
             </div>

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/NameAndProfileSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/sections/NameAndProfileSection.tsx
@@ -8,7 +8,11 @@ import Image from "next/image";
 import { Badge, Button, Input, Text, Modal, Textarea } from "@packages/spark-ui";
 import { useRouter } from "next/navigation";
 import { UserProfile, useUpdateSparkmateProfile } from "@/features/sparkmates";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import {
+  parseCustomButtonLinks,
+  serializeCustomButtonLinks,
+} from "../../../utils/customButtonFavorites";
 
 const StyledInputContainer = ({ children }: { children: React.ReactNode }) => (
   <div className="relative group w-full rounded-[8px] p-[1px] focus-within:p-[2px] bg-[#737373] hover:bg-gradient-to-r focus-within:bg-gradient-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_0_10px_rgba(251,44,54,0.35),0_0_20px_rgba(240,177,0,0.3),0_0_32px_rgba(43,127,255,0.4)] transition-all duration-300 ease-in-out">
@@ -42,11 +46,17 @@ export const NameAndProfileSection = ({
     portfolioWebsiteUrl: profile.portfolioWebsiteUrl || "",
   });
 
-  const [links, setLinks] = useState<string[]>(profile.otherLinks || []);
+  const parsedProfileLinks = useMemo(
+    () => parseCustomButtonLinks(profile.otherLinks),
+    [profile.otherLinks],
+  );
+  const [links, setLinks] = useState<string[]>(parsedProfileLinks.links);
   const [newLink, setNewLink] = useState("");
 
   // Sync when profile is refreshed after query invalidation
-  useEffect(() => { setLinks(profile.otherLinks ?? []); }, [profile.otherLinks]);
+  useEffect(() => {
+    setLinks(parsedProfileLinks.links);
+  }, [parsedProfileLinks]);
 
   const handleAddLink = () => {
     if (newLink && !links.includes(newLink)) {
@@ -81,7 +91,12 @@ export const NameAndProfileSection = ({
   };
 
   const handleSaveLinks = () => {
-    updateProfile({ otherLinks: links }, { onSuccess: () => setIsLinksModalOpen(false) });
+    updateProfile(
+      {
+        otherLinks: serializeCustomButtonLinks(links, parsedProfileLinks.starredUrls),
+      },
+      { onSuccess: () => setIsLinksModalOpen(false) },
+    );
   };
 
   const fullName =

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
@@ -8,7 +8,6 @@ import {
   Badge,
   Button,
   Input,
-  ShineBorder,
   Text,
 } from "@packages/spark-ui";
 import { toast } from "react-toastify";
@@ -28,6 +27,7 @@ import {
   normalizeSparkmatesSectionOrder,
   SparkmatesSectionId,
 } from "../../sectionOrder";
+import { parseCustomButtonLinks } from "../../utils/customButtonFavorites";
 
 const viewIcon = (
   <svg
@@ -397,9 +397,11 @@ export function ProfilePublicView({
 
   const avatarUrl = profile?.avatarUrl || ASSETS.PROFILE.DEFAULT_AVATAR;
 
-  const customLinks = (profile?.otherLinks ?? []).map((url) => ({
+  const parsedCustomButtonLinks = parseCustomButtonLinks(profile?.otherLinks);
+  const customLinks = parsedCustomButtonLinks.links.map((url) => ({
     title: getLinkTitle(url),
     url,
+    isStarred: parsedCustomButtonLinks.starredUrls.has(url),
   }));
 
   const projectList = projectsQuery.data || [];
@@ -433,19 +435,12 @@ export function ProfilePublicView({
             {customLinks.map((item, index) => (
               <div
                 key={`${item.title}-${index}`}
-                className="relative overflow-hidden rounded-2xl border border-white/20 bg-[rgba(255,255,255,0.05)] p-5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)] transition-[border-color,box-shadow] duration-300"
+                className={`relative overflow-hidden rounded-2xl p-5 shadow-[inset_0px_4px_16px_rgba(255,255,255,0.25)] transition-[box-shadow,background] duration-300 ${
+                  item.isStarred
+                    ? "rainbow-border bg-[#0F2449] bg-[linear-gradient(90deg,#0F2449_0%,#2A4F91_50%,#0F2449_100%)]"
+                    : "border border-white/20 bg-[rgba(255,255,255,0.05)]"
+                }`}
               >
-                <ShineBorder
-                  borderWidth={1.25}
-                  duration={9}
-                  shineColor={[
-                    "#FB2C36",
-                    "#F0B100",
-                    "#00C950",
-                    "#2B7FFF",
-                  ]}
-                  className="opacity-100 transition-opacity duration-300"
-                />
                 <div className="flex items-start justify-between">
                   <div className="min-w-0 flex-1">
                     <Text

--- a/apps/nexus-web/src/features/sparkmates/utils/customButtonFavorites.ts
+++ b/apps/nexus-web/src/features/sparkmates/utils/customButtonFavorites.ts
@@ -1,0 +1,47 @@
+const STARRED_PREFIX = "__sparkmates_starred__::";
+
+export type ParsedCustomButtonLinks = {
+  links: string[];
+  starredUrls: Set<string>;
+};
+
+export function parseCustomButtonLinks(storedLinks: string[] | null | undefined): ParsedCustomButtonLinks {
+  const links: string[] = [];
+  const starredUrls = new Set<string>();
+  const seen = new Set<string>();
+
+  for (const rawEntry of storedLinks ?? []) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+
+    const isStarred = entry.startsWith(STARRED_PREFIX);
+    const rawUrl = isStarred ? entry.slice(STARRED_PREFIX.length) : entry;
+    const url = rawUrl.trim();
+
+    if (!url || seen.has(url)) {
+      if (isStarred && url) starredUrls.add(url);
+      continue;
+    }
+
+    seen.add(url);
+    links.push(url);
+    if (isStarred) starredUrls.add(url);
+  }
+
+  return { links, starredUrls };
+}
+
+export function serializeCustomButtonLinks(links: string[], starredUrls: Set<string>): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawUrl of links) {
+    const url = rawUrl.trim();
+    if (!url || seen.has(url)) continue;
+
+    seen.add(url);
+    result.push(starredUrls.has(url) ? `${STARRED_PREFIX}${url}` : url);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## closes #811 

This pull request refactors how custom button links (including "starred" favorites) are handled in Sparkmates profile sections. The main improvement is the introduction of a new utility for parsing and serializing custom button links, enabling users to star/unstar links, persist their state, and display them with special styling. The update also removes the old `ShineBorder` visual and replaces it with a new "rainbow-border" style for starred links.

Key changes:

**Custom button favorites logic:**

* Added a new utility module `customButtonFavorites.ts` to parse and serialize custom button links, supporting a "starred" state for each link. Starred links are encoded with a prefix and managed as a set for deduplication and efficient lookup.
* Updated all relevant components (`CustomButtonsSection`, `NameAndProfileSection`, `ProfilePublicView`) to use `parseCustomButtonLinks` and `serializeCustomButtonLinks` for consistent link and favorite management. [[1]](diffhunk://#diff-0f432ab37d65fc6b947c086bcf7f827e538ea6f5139d437af82188bf7269ffe5R13-R46) [[2]](diffhunk://#diff-81fce7e9b91e7b738c1b34e86afa0956835b5d629d40178d92f09eb11165628bL11-R15) [[3]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46R30) [[4]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L400-R404)

**UI/UX improvements:**

* Changed the visual indication for starred custom buttons: removed the `ShineBorder` component and replaced it with a "rainbow-border" and gradient background for starred links in both owner and public profile views. [[1]](diffhunk://#diff-0f432ab37d65fc6b947c086bcf7f827e538ea6f5139d437af82188bf7269ffe5L83-L94) [[2]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L436-L448)
* Updated the star toggling logic to use URLs instead of indices, ensuring correct behavior even if the list order changes. [[1]](diffhunk://#diff-0f432ab37d65fc6b947c086bcf7f827e538ea6f5139d437af82188bf7269ffe5R13-R46) [[2]](diffhunk://#diff-0f432ab37d65fc6b947c086bcf7f827e538ea6f5139d437af82188bf7269ffe5L112-R130)
* Ensured that removing a link also removes its starred state and that all link state is kept in sync with the profile data. [[1]](diffhunk://#diff-0f432ab37d65fc6b947c086bcf7f827e538ea6f5139d437af82188bf7269ffe5R59-R76) [[2]](diffhunk://#diff-81fce7e9b91e7b738c1b34e86afa0956835b5d629d40178d92f09eb11165628bL45-R59) [[3]](diffhunk://#diff-81fce7e9b91e7b738c1b34e86afa0956835b5d629d40178d92f09eb11165628bL84-R99)

These changes make the custom button/favorites feature more robust, user-friendly, and visually consistent across the app.