### PR TITLE
refactor(nexus-web): transform loading screens and skeletons to match GDG nexus branding

### DIFF
--- a/apps/nexus-web/src/app/articles/[articleId]/loading.tsx
+++ b/apps/nexus-web/src/app/articles/[articleId]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading article..." />;
+}

--- a/apps/nexus-web/src/app/articles/loading.tsx
+++ b/apps/nexus-web/src/app/articles/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading stories..." />;
+}

--- a/apps/nexus-web/src/app/nfc-cards/[cardId]/activate/loading.tsx
+++ b/apps/nexus-web/src/app/nfc-cards/[cardId]/activate/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Preparing card activation..." />;
+}

--- a/apps/nexus-web/src/app/nfc-cards/[cardId]/loading.tsx
+++ b/apps/nexus-web/src/app/nfc-cards/[cardId]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading card details..." />;
+}

--- a/apps/nexus-web/src/app/sparkmates/[gdgId]/loading.tsx
+++ b/apps/nexus-web/src/app/sparkmates/[gdgId]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading member profile..." />;
+}

--- a/apps/nexus-web/src/app/sparkmates/loading.tsx
+++ b/apps/nexus-web/src/app/sparkmates/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading Sparkmates..." />;
+}

--- a/apps/nexus-web/src/app/sparkmates/me/analytics/loading.tsx
+++ b/apps/nexus-web/src/app/sparkmates/me/analytics/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading analytics..." />;
+}

--- a/apps/nexus-web/src/app/sparkmates/me/settings/loading.tsx
+++ b/apps/nexus-web/src/app/sparkmates/me/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading settings..." />;
+}

--- a/apps/nexus-web/src/app/sparkmates/me/sparky-points/loading.tsx
+++ b/apps/nexus-web/src/app/sparkmates/me/sparky-points/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingScreen } from "@/components/shared";
+
+export default function Loading() {
+  return <LoadingScreen message="Loading Sparky Points..." />;
+}

--- a/apps/nexus-web/src/components/shared/BrandedSkeleton.tsx
+++ b/apps/nexus-web/src/components/shared/BrandedSkeleton.tsx
@@ -1,0 +1,63 @@
+import { Skeleton } from "@packages/spark-ui";
+import { cn } from "@/lib/utils";
+import type { HTMLAttributes } from "react";
+
+type BrandedSkeletonVariant = "block" | "text" | "chip" | "button";
+
+interface BrandedSkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: BrandedSkeletonVariant;
+  withGradientRing?: boolean;
+}
+
+const variantClassMap: Record<BrandedSkeletonVariant, string> = {
+  block: "rounded-xl",
+  text: "h-4 rounded-md",
+  chip: "h-6 rounded-full",
+  button: "h-10 rounded-md",
+};
+
+/**
+ * Nexus branded skeleton placeholder.
+ * Uses glassy dark surfaces and optional 4-color GDG ring accents.
+ */
+export function BrandedSkeleton({
+  className,
+  variant = "block",
+  withGradientRing = false,
+  ...props
+}: BrandedSkeletonProps) {
+  if (!withGradientRing) {
+    return (
+      <Skeleton
+        className={cn(
+          "border border-white/10 bg-white/10",
+          variantClassMap[variant],
+          className,
+        )}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl p-px",
+        variant === "chip" && "rounded-full",
+        className,
+      )}
+      style={{
+        background:
+          "linear-gradient(90deg, rgba(234,67,53,0.85) 0%, rgba(249,171,0,0.85) 33%, rgba(52,168,83,0.85) 66%, rgba(66,133,244,0.85) 100%)",
+      }}
+      {...props}
+    >
+      <Skeleton
+        className={cn(
+          "h-full w-full border border-white/5 bg-[#0F0E0E]/80",
+          variantClassMap[variant],
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/nexus-web/src/components/shared/LoadingScreen.tsx
+++ b/apps/nexus-web/src/components/shared/LoadingScreen.tsx
@@ -13,12 +13,23 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({
 }) => {
   return (
     <div
-      className={`flex flex-col items-center justify-center gap-4 ${
+      className={`relative overflow-hidden flex flex-col items-center justify-center gap-5 bg-[#0F0E0E] ${
         fullPage ? "min-h-screen" : "py-16"
       }`}
     >
-      <GdgLoader />
-      <p className="text-sm text-gray-400">{message}</p>
+      <div
+        className="pointer-events-none absolute inset-0 opacity-60"
+        style={{
+          background:
+            "radial-gradient(45% 35% at 50% 35%, rgba(66,133,244,0.24) 0%, rgba(66,133,244,0) 70%), radial-gradient(40% 30% at 28% 70%, rgba(234,67,53,0.2) 0%, rgba(234,67,53,0) 70%), radial-gradient(40% 30% at 72% 70%, rgba(52,168,83,0.2) 0%, rgba(52,168,83,0) 70%)",
+        }}
+      />
+      <div className="relative rounded-2xl p-px" style={{ background: "linear-gradient(90deg, #EA4335, #F9AB00, #34A853, #4285F4)" }}>
+        <div className="rounded-2xl bg-[#111213]/90 px-8 py-7 backdrop-blur-md">
+          <GdgLoader />
+        </div>
+      </div>
+      <p className="relative text-sm text-white/75">{message}</p>
     </div>
   );
 };

--- a/apps/nexus-web/src/components/shared/index.ts
+++ b/apps/nexus-web/src/components/shared/index.ts
@@ -1,4 +1,5 @@
 export { AuthGuard } from "./AuthGuard";
+export { BrandedSkeleton } from "./BrandedSkeleton";
 export { CosmosParticles } from "./CosmosParticles";
 export { Footer } from "./Footer";
 export { LoadingScreen } from "./LoadingScreen";

--- a/apps/nexus-web/src/features/events/components/EventsCalendar.tsx
+++ b/apps/nexus-web/src/features/events/components/EventsCalendar.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Card, Text, Skeleton } from "@packages/spark-ui";
+import { Card, Text } from "@packages/spark-ui";
 import { useEvents } from "../hooks/useEvents";
 import type { Event } from "../types";
 import { cn } from "@/lib/utils";
 import { ASSETS } from "@/lib/constants/assets";
+import { BrandedSkeleton } from "@/components/shared";
 import { normalizeEventDescription } from "../utils/description";
 import { DateSelector } from "./DateSelector";
 
@@ -139,11 +140,17 @@ const EVENT_SEQUENCE_GRADIENTS = [
 function EventSkeleton() {
   return (
     <div className="absolute inset-0 z-10 overflow-hidden">
-      <div className="absolute inset-0 animate-pulse opacity-70 bg-muted" />
+      <div
+        className="absolute inset-0 opacity-80"
+        style={{
+          background:
+            "linear-gradient(135deg, rgba(22,36,86,0.28) 0%, rgba(66,133,244,0.16) 45%, rgba(234,67,53,0.18) 100%)",
+        }}
+      />
       <div className="relative z-20 h-full md:p-2 flex flex-col">
         <div className="mt-auto space-y-1 md:space-y-2">
-          <Skeleton className="h-1.5 md:h-3 w-4/5 bg-black/15 border-none" />
-          <Skeleton className="h-1.5 md:h-3 w-1/2 bg-black/10 border-none" />
+          <BrandedSkeleton className="h-1.5 md:h-3 w-4/5" variant="text" />
+          <BrandedSkeleton className="h-1.5 md:h-3 w-1/2" variant="text" />
         </div>
       </div>
     </div>

--- a/apps/nexus-web/src/features/events/components/GalleryYearSection.tsx
+++ b/apps/nexus-web/src/features/events/components/GalleryYearSection.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Container, Skeleton, Stack, Text } from "@packages/spark-ui";
+import { Container, Stack, Text } from "@packages/spark-ui";
 import type { Event } from "../types";
 import {
   normalizeEventDescription,
   splitBoldSegments,
 } from "../utils/description";
 import { useEvents } from "../hooks/useEvents";
+import { BrandedSkeleton } from "@/components/shared";
 
 type GalleryYearSectionProps = {
   yearParam: string;
@@ -268,29 +269,29 @@ export function GalleryYearSection({ yearParam }: GalleryYearSectionProps) {
               {[1, 2, 3, 4].map((i) => (
                 <div key={i} className="animate-pulse">
                   {/* One big rectangle skeleton */}
-                  <Skeleton className="h-[220px] md:h-[560px] w-full rounded-2xl bg-white/10 border border-white/10" />
+                  <BrandedSkeleton className="h-[220px] md:h-[560px] w-full rounded-2xl" withGradientRing />
 
                   <div className="mt-5 md:mt-7 space-y-6">
                     {/* Big text skeleton like a title */}
                     <div className="flex justify-center md:justify-start">
-                      <Skeleton className="h-7 md:h-12 w-3/4 md:w-1/2 rounded-lg bg-white/10" />
+                      <BrandedSkeleton className="h-7 md:h-12 w-3/4 md:w-1/2 rounded-lg" />
                     </div>
                     {/* Event details */}
                     <div className="flex flex-nowrap items-center justify-center gap-2 md:gap-5">
-                      <Skeleton className="h-4 w-12 md:w-16 rounded-full bg-white/10" />
-                      <Skeleton className="h-4 w-24 md:w-32 rounded-lg bg-white/10" />
-                      <Skeleton className="h-4 w-16 md:w-20 rounded-lg bg-white/10" />
+                      <BrandedSkeleton className="h-4 w-12 md:w-16" variant="chip" />
+                      <BrandedSkeleton className="h-4 w-24 md:w-32 rounded-lg" />
+                      <BrandedSkeleton className="h-4 w-16 md:w-20 rounded-lg" />
                     </div>
 
                     {/* Three stack of smaller text skeletons (description) */}
                     <div className="space-y-3">
-                      <Skeleton className="h-4 w-full rounded bg-white/10" />
-                      <Skeleton className="h-4 w-full rounded bg-white/10" />
-                      <Skeleton className="h-4 w-3/4 rounded bg-white/10" />
+                      <BrandedSkeleton className="h-4 w-full rounded" />
+                      <BrandedSkeleton className="h-4 w-full rounded" />
+                      <BrandedSkeleton className="h-4 w-3/4 rounded" />
                     </div>
 
                     {/* Rectangle skeleton at the bottom (button) */}
-                    <Skeleton className="h-10 md:h-11 w-full rounded-md bg-white/10 border border-white/5 mt-6 md:mt-7" />
+                    <BrandedSkeleton className="h-10 md:h-11 w-full rounded-md mt-6 md:mt-7" variant="button" withGradientRing />
                   </div>
                 </div>
               ))}

--- a/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseAchievements.tsx
+++ b/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseAchievements.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   CardFooter,
   CardHeader,
-  Skeleton,
   Stack,
   Text,
 } from "@packages/spark-ui";
@@ -22,6 +21,7 @@ import {
 import { useMemberShowcases } from "../hooks/useMemberShowcases";
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
+import { BrandedSkeleton } from "@/components/shared";
 
 const achievementsSectionVariants = createSectionVariants(
   SECTION_DELAYS.achievements,
@@ -33,15 +33,16 @@ function AchievementSkeletonCard() {
     <Card className="relative w-full overflow-hidden bg-[#1d2231]/85 shadow-[0_7px_18px_rgba(0,0,0,0.25)] backdrop-blur-md">
       <div className="relative z-10">
         {/* Fixed 293×208 aspect ratio skeleton matches the image wrapper */}
-        <Skeleton
+        <BrandedSkeleton
           className="w-full rounded-lg"
           style={{ aspectRatio: "293/208" }}
+          withGradientRing
         />
         <div className="mt-3 px-4 md:mt-3.5">
-          <Skeleton className="h-6 w-3/4" />
+          <BrandedSkeleton className="h-6 w-3/4" />
         </div>
         <div className="mt-4 flex justify-end px-4 pb-4 md:mt-5">
-          <Skeleton className="h-10 w-10 rounded-md" />
+          <BrandedSkeleton className="h-10 w-10 rounded-md" variant="button" />
         </div>
       </div>
     </Card>

--- a/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseSpotlight.tsx
+++ b/apps/nexus-web/src/features/member-showcase/components/MemberShowcaseSpotlight.tsx
@@ -2,29 +2,30 @@
 
 import Image from "next/image";
 import { motion, useReducedMotion } from "motion/react";
-import { Button, Inline, Skeleton, Stack, Text } from "@packages/spark-ui";
+import { Button, Inline, Stack, Text } from "@packages/spark-ui";
 import { ASSETS } from "@/lib/constants/assets";
 import { ITEM_VARIANTS } from "./memberShowcaseMotion";
 import { useSpotlight } from "../hooks/useSpotlight";
 import Link from "next/link";
 import { formatDate } from "@/lib/utils";
+import { BrandedSkeleton } from "@/components/shared";
 
 function SpotlightSkeleton() {
   return (
     <div className="flex flex-col items-center gap-8 px-0 md:gap-10 md:px-6 lg:flex-row lg:gap-12 lg:px-24">
       {/* Image skeleton with Sparky overlaid */}
       <div className="relative w-full shrink-0 lg:w-120">
-        <Skeleton className="w-full rounded-2xl" style={{ aspectRatio: "640/390" }} />
+        <BrandedSkeleton className="w-full rounded-2xl" style={{ aspectRatio: "640/390" }} withGradientRing />
       </div>
       {/* Text skeleton */}
       <div className="flex-1 w-full">
         <Stack gap="md">
-          <Skeleton className="h-8 w-3/4" />
-          <Skeleton className="h-4 w-1/3" />
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-5/6" />
-          <Skeleton className="h-4 w-4/6" />
-          <Skeleton className="h-10 w-32 mt-2" />
+          <BrandedSkeleton className="h-8 w-3/4" />
+          <BrandedSkeleton className="h-4 w-1/3" variant="text" />
+          <BrandedSkeleton className="h-4 w-full" variant="text" />
+          <BrandedSkeleton className="h-4 w-5/6" variant="text" />
+          <BrandedSkeleton className="h-4 w-4/6" variant="text" />
+          <BrandedSkeleton className="h-10 w-32 mt-2" variant="button" withGradientRing />
         </Stack>
       </div>
     </div>

--- a/apps/nexus-web/src/features/products/components/StudyJamContainer.tsx
+++ b/apps/nexus-web/src/features/products/components/StudyJamContainer.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import Image from "next/image";
-import { Skeleton } from "@packages/spark-ui";
+import { BrandedSkeleton } from "@/components/shared";
 import {
   normalizeEventDescription,
   splitBoldSegments,
@@ -98,7 +98,7 @@ export function StudyJamContainer({
               className="w-full aspect-square rounded-[11px] object-cover bg-white/5"
             />
           ) : (
-            <Skeleton className="w-full aspect-square rounded-[11px] bg-white/10 border border-white/5" />
+            <BrandedSkeleton className="w-full aspect-square rounded-[11px]" withGradientRing />
           )}
         </div>
 
@@ -106,12 +106,12 @@ export function StudyJamContainer({
         <div className="flex w-full flex-col items-center gap-3.25 text-center">
           <div className="min-h-[3.5rem] text-white text-2xl leading-tight font-bold text-center line-clamp-2">
             {title ?? (
-              <Skeleton className="mx-auto h-8 w-2/3 rounded-md bg-white/10 border border-white/5" />
+              <BrandedSkeleton className="mx-auto h-8 w-2/3 rounded-md" />
             )}
           </div>
           <div className="min-h-[1rem] text-xs italic text-white/90 text-center line-clamp-1">
             {subtitle ?? (
-              <Skeleton className="mx-auto h-5 w-1/2 rounded-md bg-white/10 border border-white/5" />
+              <BrandedSkeleton className="mx-auto h-5 w-1/2 rounded-md" />
             )}
           </div>
         </div>
@@ -123,9 +123,9 @@ export function StudyJamContainer({
               renderDescriptionContent(description)
             ) : (
               <div className="w-full space-y-2">
-                <Skeleton className="h-3 w-full rounded bg-white/10" />
-                <Skeleton className="h-3 w-5/6 rounded bg-white/10" />
-                <Skeleton className="h-3 w-2/3 rounded bg-white/10" />
+                <BrandedSkeleton className="h-3 w-full rounded" variant="text" />
+                <BrandedSkeleton className="h-3 w-5/6 rounded" variant="text" />
+                <BrandedSkeleton className="h-3 w-2/3 rounded" variant="text" />
               </div>
             )}
           </div>
@@ -137,13 +137,13 @@ export function StudyJamContainer({
                 </span>
               ) : (
                 (category ?? (
-                  <Skeleton className="h-6 w-28 rounded-full bg-white/10 border border-white/5" />
+                  <BrandedSkeleton className="h-6 w-28" variant="chip" />
                 ))
               )}
             </div>
             <div className="text-xs text-white/80">
               {date ?? (
-                <Skeleton className="h-4 w-20 rounded-md bg-white/10 border border-white/5" />
+                <BrandedSkeleton className="h-4 w-20 rounded-md" variant="text" />
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary

This pull request introduces a new `BrandedSkeleton` component for Nexus-branded loading placeholders and refactors the app to use it in place of the generic `Skeleton` component from `spark-ui`. Additionally, it enhances the visual design of loading screens with branded backgrounds and gradients, and updates loading pages across various routes to use the improved `LoadingScreen` component.

## Component and UI improvements:

* Added a new `BrandedSkeleton` component in `apps/nexus-web/src/components/shared/BrandedSkeleton.tsx` that provides branded skeleton placeholders with glassy dark surfaces and optional GDG ring accents.
* Updated the `LoadingScreen` component to include a branded gradient background and improved styling for a more polished loading experience.

## Refactoring and usage updates:

* Replaced all usages of the generic `Skeleton` component in event, member showcase, and product feature components with the new `BrandedSkeleton` for a consistent, branded look. 
* Exported the new `BrandedSkeleton` from the shared components index for easy import throughout the app.

## Loading screen consistency:

* Added or updated route-level loading screens for articles, NFC cards, and Sparkmates sections to use the improved `LoadingScreen` with context-specific messages. 

## Related Issues
closes #825 