### PR TITLE
fix(nexus-web): fix horizon image covering text in community showcase

### DIFF
--- a/apps/nexus-web/src/features/community-showcase/components/DesktopShowcase.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/DesktopShowcase.tsx
@@ -58,6 +58,7 @@ export function DesktopShowcase({ onOpenModal, events }: DesktopShowcaseProps) {
               align="center"
               weight="bold"
               className="z-20"
+              style={{ filter: 'drop-shadow(0 0 20px rgba(0,0,0,1)) drop-shadow(0 2px 10px rgba(0,0,0,0.9))' }}
             >
               Community Showcase
             </Text>
@@ -67,6 +68,7 @@ export function DesktopShowcase({ onOpenModal, events }: DesktopShowcaseProps) {
               weight="bold"
               align="center"
               className="text-white z-10"
+              style={{ textShadow: '0 0 24px rgba(0,0,0,1), 0 2px 12px rgba(0,0,0,0.9)' }}
             >
               Discover what our community has been building together.
             </Text>
@@ -74,7 +76,7 @@ export function DesktopShowcase({ onOpenModal, events }: DesktopShowcaseProps) {
 
           {/* Horizon illustration */}
           <img
-            className="w-[min(1700px,140vw)] h-auto max-w-none left-1/2 -translate-x-1/2 -top-30 absolute"
+            className="w-[min(1700px,140vw)] h-auto max-w-none left-1/2 -translate-x-1/2 -top-30 absolute -z-10"
             src="/community-showcase/community-showcase-horizon.webp"
             alt=""
           />

--- a/apps/nexus-web/src/features/community-showcase/components/EventModal.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/EventModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Event } from "@/features/events";
+import { normalizeEventDescription } from "@/features/events/utils/description";
 
 /**
  * EventModal
@@ -94,9 +95,7 @@ export function EventModal({ isVisible, onClose, event }: EventModalProps) {
                   "opacity 700ms ease 80ms, transform 800ms cubic-bezier(0.22,1,0.36,1)",
               }}
             >
-              {
-                event.description
-              }
+              {normalizeEventDescription(event.description)}
               {/* Join us for an empowering session on February 27, 2026, from 8:00
               PM to 9:30 PM, as we delve into the world of intermediate UI/UX
               design! In the &quot;Interactive UI/UX Design Bootcamp,&quot;

--- a/apps/nexus-web/src/features/community-showcase/components/FeaturedEventCard.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/FeaturedEventCard.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Card, Stack, Text } from "@packages/spark-ui";
 import { Event } from "@/features/events";
 import { ASSETS } from "@/lib/constants/assets";
+import { normalizeEventDescription } from "@/features/events/utils/description";
 
 /**
  * FeaturedEventCard
@@ -30,7 +31,7 @@ export function FeaturedEventCard({ onOpenModal, event }: FeaturedEventCardProps
 
 
 
-const ABOUT_TEXT = event.description || "No description available for this event.";
+const ABOUT_TEXT = normalizeEventDescription(event.description) || "No description available for this event.";
 
 const TRUNCATED_ABOUT =
   ABOUT_TEXT.length > 493 ? ABOUT_TEXT.slice(0, 493) + "..." : ABOUT_TEXT;
@@ -58,6 +59,7 @@ const TRUNCATED_ABOUT =
           align="center"
           color="on-secondary"
           className="z-10"
+          style={{ textShadow: '0 0 20px rgba(0,0,0,1), 0 2px 10px rgba(0,0,0,0.9)' }}
         >
           {new Date(event.end_date).toLocaleString("en-US", {
             month: "long",
@@ -73,6 +75,7 @@ const TRUNCATED_ABOUT =
           align="center"
           color="on-secondary"
           className="mt-4 z-10"
+          style={{ textShadow: '0 0 20px rgba(0,0,0,1), 0 2px 10px rgba(0,0,0,0.9)' }}
         >
           Today&apos;s Highlight
         </Text>
@@ -147,7 +150,7 @@ const TRUNCATED_ABOUT =
                   className={is39Hovered ? "" : "text-white"}
                   gradient={is39Hovered ? "white-blue" : undefined}
                 >
-                  39
+                  {event.rsvp ?? event.attendees_count}
                 </Text>
               </div>
               <div
@@ -171,7 +174,7 @@ const TRUNCATED_ABOUT =
               className="h-9 max-w-72 px-3 py-1 rounded-2xl outline-[1.50px] outline-offset-[-1.50px] outline-white inline-flex flex-col justify-center items-center gap-2"
             >
               <Text variant="body" color="on-secondary">
-                TODO: Team Here
+                {event.category}
               </Text>
             </div>
           </Stack>

--- a/apps/nexus-web/src/features/community-showcase/components/MobileShowcase.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/MobileShowcase.tsx
@@ -8,6 +8,7 @@ import { PlanetCard } from "./PlanetCard";
 import { CarouselArrowIcon } from "./CarouselArrowIcon";
 import { Event, useEvents } from "@/features/events";
 import { useListEvents } from "@/features/events/hooks/useListEvents";
+import { normalizeEventDescription } from "@/features/events/utils/description";
 import { ASSETS } from "@/lib/constants/assets";
 import { useRouter } from "next/navigation";
 
@@ -78,6 +79,7 @@ export function MobileShowcase({events } : {events: Event[]}) {
           align="center"
           weight="bold"
           className="z-20"
+          style={{ filter: 'drop-shadow(0 0 20px rgba(0,0,0,1)) drop-shadow(0 2px 10px rgba(0,0,0,0.9))' }}
         >
           Community Showcase
         </Text>
@@ -103,14 +105,17 @@ export function MobileShowcase({events } : {events: Event[]}) {
         >
           {EVENTS[0]?.title}
         </Text>
-        <Text variant="body" align="center" color="on-secondary">
+        <Text
+          variant="body"
+          align="center"
+          color="on-secondary"
+          style={{ textShadow: '0 0 20px rgba(0,0,0,1), 0 2px 10px rgba(0,0,0,0.9)' }}
+        >
           {new Date(EVENTS[0]?.end_date).toLocaleDateString(undefined, {
             month: "short",
             year: "numeric",
             day: "numeric",
-            
           })}
-          {/* MS Teams &nbsp; • &nbsp; Feb 27, 2026, 8:00 PM - 9:30 PM */}
         </Text>
         <img
           className="w-120 h-auto max-w-none left-1/2 -translate-x-1/2 top-32 absolute -z-10"
@@ -123,6 +128,7 @@ export function MobileShowcase({events } : {events: Event[]}) {
           color="on-secondary"
           className="mt-2"
           weight="semibold"
+          style={{ textShadow: '0 0 20px rgba(0,0,0,1), 0 2px 10px rgba(0,0,0,0.9)' }}
         >
           Today&apos;s Highlight
         </Text>
@@ -141,14 +147,12 @@ export function MobileShowcase({events } : {events: Event[]}) {
             className="h-9 px-3 py-1 rounded-lg outline-[1.50px] outline-offset-[-1.50px] outline-white flex items-center"
           >
             <Text variant="body" color="on-secondary" className="z-10">
-              TODO: PUT TEAM HERE
-              {/* UI / UX Designs */}
+              {EVENTS[0]?.category}
             </Text>
           </div>
           <div className="flex flex-col items-end mt-0">
             <Text variant="heading-4" className="text-white">
-              {/* {EVENTS[0]?.attendees_count || 0} */}
-              39
+              {EVENTS[0]?.rsvp ?? EVENTS[0]?.attendees_count ?? 0}
             </Text>
             <Text variant="body" className="text-white leading-5">
               RSVP&apos;d
@@ -161,21 +165,10 @@ export function MobileShowcase({events } : {events: Event[]}) {
           variant="body"
           className="text-white mt-4 leading-7 self-stretch text-center justify-start"
         >
-          {EVENTS[0]?.description}
-          {/* Join us for an empowering session on February 27, 2026, from 8:00 PM
-          to 9:30 PM, as we delve into the world of intermediate UI/UX design!
-          In the &quot;Interactive UI/UX Design Bootcamp,&quot; we&apos;ll
-          transform your ideas into reality by guiding you through the creation
-          of both low- and high-fidelity wireframes. Learn how to turn these
-          wireframes into interactive prototypes to showcase real user flows.
-          We&apos;ll introduce key Figma features like Auto Layout and
-          Components that boost design efficiency and maintain consistency. To
-          top it all off, engage in our &quot;Hero Maker: Proto-Design
-          Challenge,&quot; a mini design task where you can apply what
-          you&apos;ve learned. Become part of the design revolution and elevate
-          your skills with GDG PUP! Don&apos;t miss this opportunity to enhance
-          your design capabilities. Book your seat today and bring your vision
-          to life! */}
+          {(() => {
+            const desc = normalizeEventDescription(EVENTS[0]?.description);
+            return desc.length > 300 ? desc.slice(0, 300) + "..." : desc;
+          })()}
         </Text>
       </Stack>
 


### PR DESCRIPTION
fixed horizon light and text. Making the text visible over the horizon light 
<img width="1230" height="973" alt="Screenshot 2026-04-14 082554" src="https://github.com/user-attachments/assets/04cd3df3-aaa4-409a-a9d0-4120f3b4e252" />
<img width="1188" height="919" alt="Screenshot 2026-04-14 082530" src="https://github.com/user-attachments/assets/05018005-0903-4416-ae54-1a2f3503becc" />
<img width="860" height="916" alt="Screenshot 2026-04-14 082108" src="https://github.com/user-attachments/assets/e63987f0-6c56-44cf-b237-d4608e70fc00" />


Closes #746 