### PR TITLE
fix(articles): improve page scroll and back button UI

### DIFF
--- a/apps/nexus-web/src/app/articles/[articleId]/page.tsx
+++ b/apps/nexus-web/src/app/articles/[articleId]/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { ArticlePreview } from "@/features/articles/components/ArticlePreview";
-import { useNfcCard } from "@/features/nfc-cards/hooks/useNfcCard";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useEffect } from "react";
 
 const NfcPage = () => {
-  const { articleId } = useParams(); 
+  const { articleId } = useParams();
 
-
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   return <>
     <ArticlePreview articleId={articleId as string} />

--- a/apps/nexus-web/src/features/articles/components/ArticlePreview.tsx
+++ b/apps/nexus-web/src/features/articles/components/ArticlePreview.tsx
@@ -282,9 +282,8 @@ return (
             <button
               type="button"
               onClick={handleBack}
-              className="flex items-center gap-2 text-gray-400 hover:text-white transition-all group"
+              className="flex items-center gap-2 text-gray-400 hover:text-white transition-all"
             >
-              <span className="transition-transform group-hover:-translate-x-1">←</span> 
               Back
             </button>
             <span className="text-gray-500 bg-white/5 px-3 py-1 rounded-full border border-white/10">


### PR DESCRIPTION

This pull request introduces a small UI improvement and a minor code cleanup in the article page and the `ArticlePreview` component.

UI and UX Improvements:

* `apps/nexus-web/src/app/articles/[articleId]/page.tsx`: Added a `useEffect` hook to automatically scroll to the top of the page when the article page is loaded, improving user experience when navigating between articles. ([apps/nexus-web/src/app/articles/[articleId]/page.tsxL4-R12](diffhunk://#diff-18b4b4fe259dbc5e7d5dadd2547e3a75f19b529a9d44de963b6e3f495f8ec9dbL4-R12))

Code and Style Cleanup:

* [`apps/nexus-web/src/features/articles/components/ArticlePreview.tsx`](diffhunk://#diff-c61e13d68105110909a15852534c7b7be98dc5a0d09493ec01c2d1083f01c419L285-L287): Simplified the back button by removing the left arrow icon and the unused `group` class, resulting in a cleaner appearance.

Closes #887