### PR TITLE
chore(nexus-web): minimized the padding height for pages for consistency

### DIFF
--- a/apps/nexus-web/src/features/about/components/AboutSection.tsx
+++ b/apps/nexus-web/src/features/about/components/AboutSection.tsx
@@ -31,7 +31,7 @@ const FadeInSection = ({
 
 export function AboutSection() {
   return (
-    <div className="relative overflow-x-hidden pt-60 pb-48 px-4 md:px-8 lg:px-16">
+    <div className="relative overflow-x-hidden pt-32 md:pt-48 pb-16 md:pb-28 px-4 md:px-8 lg:px-16">
       {/* Decorative Ellipse - Top Left */}
       <div
         className="absolute rounded-full pointer-events-none"

--- a/apps/nexus-web/src/features/about/components/BenefitsSection.tsx
+++ b/apps/nexus-web/src/features/about/components/BenefitsSection.tsx
@@ -240,7 +240,7 @@ const BenefitCard = ({ benefit }: { benefit: typeof benefits[0] }) => {
 
 export function BenefitsSection() {
   return (
-    <div className="relative overflow-hidden pt-60 pb-48 px-4 md:px-8 lg:px-16 bg-[#010B1D]">
+    <div className="relative overflow-hidden pt-32 md:pt-48 pb-16 md:pb-28 px-4 md:px-8 lg:px-16 bg-[#010B1D]">
 
       <style>{`
         /* ── Ellipses ── */

--- a/apps/nexus-web/src/features/about/components/HistorySection.tsx
+++ b/apps/nexus-web/src/features/about/components/HistorySection.tsx
@@ -520,7 +520,7 @@ const StatCard = ({
 // ─── Main component ───────────────────────────────────────────────────────────
 export function HistorySection() {
   return (
-    <div className="relative overflow-hidden pt-60 pb-48 px-4 md:px-8 lg:px-16 bg-[#0F0E0E]">
+    <div className="relative overflow-hidden pt-32 md:pt-48 pb-16 md:pb-28 px-4 md:px-8 lg:px-16 bg-[#0F0E0E]">
       {/* Zoned blob background — pinned per region, history page only */}
       <HistoryBlobBackground />
 

--- a/apps/nexus-web/src/features/about/components/PartnershipSection.tsx
+++ b/apps/nexus-web/src/features/about/components/PartnershipSection.tsx
@@ -51,7 +51,7 @@ const FadeInSection = ({
 };
 export function PartnershipSection() {
   return (
-    <div className="bg-[#010B1D] relative w-full overflow-hidden pt-32 sm:pt-60 pb-24 sm:pb-48 font-['Google_Sans',sans-serif]">
+    <div className="bg-[#010B1D] relative w-full overflow-hidden pt-32 sm:pt-48 pb-16 sm:pb-28 font-['Google_Sans',sans-serif]">
       {/* Stars Background */}
       <div className="absolute inset-x-0 bottom-0 pointer-events-none opacity-40 h-[100%] w-full z-0">
         <div

--- a/apps/nexus-web/src/features/about/components/TeamSection.tsx
+++ b/apps/nexus-web/src/features/about/components/TeamSection.tsx
@@ -620,7 +620,7 @@ export function TeamSection() {
 
   return (
     <div
-      className="relative overflow-x-clip pt-36 md:pt-60 pb-20 md:pb-48 px-4 md:px-8 lg:px-16 bg-[#010B1D]"
+      className="relative overflow-x-clip pt-32 md:pt-48 pb-16 md:pb-28 px-4 md:px-8 lg:px-16 bg-[#010B1D]"
     >
       <div
         className="absolute inset-x-0 top-0 h-[620px] pointer-events-none hidden md:block"

--- a/apps/nexus-web/src/features/community-showcase/components/CommunityShowcaseSection.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/CommunityShowcaseSection.tsx
@@ -32,7 +32,7 @@ export function CommunityShowcaseSection() {
   }
 
   return (
-    <div className="relative overflow-hidden pt-32 pb-32 md:pt-60 md:pb-48 px-4 md:px-8 lg:px-16">
+    <div className="relative overflow-hidden pt-32 md:pt-48 pb-16 md:pb-28 px-4 md:px-8 lg:px-16">
       <div className="relative mx-auto w-full max-w-7xl">
         <MobileShowcase events={EVENTS} />
         <DesktopShowcase onOpenModal={modal.openModal} events={EVENTS} />

--- a/apps/nexus-web/src/features/community-showcase/components/CommunityShowcaseSkeleton.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/CommunityShowcaseSkeleton.tsx
@@ -174,7 +174,7 @@ function MobileShowcaseSkeleton() {
 
 export function CommunityShowcaseSkeleton() {
   return (
-    <div className="relative overflow-hidden pt-32 pb-32 md:pt-60 md:pb-48 px-4 md:px-8 lg:px-16">
+    <div className="relative overflow-hidden pt-32 md:pt-48 pb-16 md:pb-28 px-4 md:px-8 lg:px-16">
       <div className="relative mx-auto w-full max-w-7xl">
         <MobileShowcaseSkeleton />
         <DesktopShowcaseSkeleton />

--- a/apps/nexus-web/src/features/events/components/EventsSection.tsx
+++ b/apps/nexus-web/src/features/events/components/EventsSection.tsx
@@ -11,7 +11,7 @@ export function EventsSection({ randomSeed }: { randomSeed?: number }) {
 
   return (
     <div
-      className="relative overflow-x-clip pt-36 md:pt-60 pb-14 md:pb-48 px-4 md:px-8 lg:px-16"
+      className="relative overflow-x-clip pt-32 md:pt-48 pb-16 md:pb-28 px-4 md:px-8 lg:px-16"
       style={{ backgroundColor: "rgba(15, 14, 14, 1)" }}
     >
       {/* Mobile blobs */}

--- a/apps/nexus-web/src/features/id/components/IdSection.tsx
+++ b/apps/nexus-web/src/features/id/components/IdSection.tsx
@@ -8,7 +8,7 @@ import { IdHowItWorks } from "./IdHowItWorks";
 
 export function IdSection() {
   return (
-    <div className="relative overflow-x-hidden min-h-screen pt-24 md:pt-44 lg:pt-60 pb-48 md:px-8 lg:px-16">
+    <div className="relative overflow-x-hidden min-h-screen pt-32 md:pt-48 pb-16 md:pb-28 md:px-8 lg:px-16">
       <IdBlobs />
 
       <Container>

--- a/apps/nexus-web/src/features/leaderboard/components/LeaderboardSection.tsx
+++ b/apps/nexus-web/src/features/leaderboard/components/LeaderboardSection.tsx
@@ -12,7 +12,7 @@ export function LeaderboardSection() {
   const [summarySource, setSummarySource] = useState<"members" | "core">("members");
 
   return (
-    <div className="relative overflow-x-hidden pt-60 pb-48 w-full min-h-screen bg-[#0b0b0b] text-white">
+    <div className="relative overflow-x-hidden pt-32 md:pt-48 pb-16 md:pb-28 w-full min-h-screen bg-[#0b0b0b] text-white">
       {/* Absolute positioned background art for the entire page */}
       <LeaderboardBackground />
 


### PR DESCRIPTION
This pull request standardizes and reduces the vertical padding (top and bottom) across multiple section components in the Nexus Web app. The changes ensure a more consistent and compact layout, especially on smaller screens, by adjusting the `pt-*` (padding-top) and `pb-*` (padding-bottom) Tailwind CSS classes. No functional or logic changes were made—these are purely layout and styling updates.

**Section padding adjustments:**

* About page sections: Reduced vertical padding in `AboutSection`, `BenefitsSection`, `HistorySection`, `PartnershipSection`, and `TeamSection` for a more uniform appearance across breakpoints. [[1]](diffhunk://#diff-30790944081d81b5848fa6074c5de5193491294e6ee44669925712805b75104bL34-R34) [[2]](diffhunk://#diff-c1b728351391e4047469206be35e8efc9b0d74ec9abe5187e05cdae4426cd833L243-R243) [[3]](diffhunk://#diff-2e58d97140d6406157a1cb5828b18059f355d5c1889bbe371a3b798b9e75d7c7L523-R523) [[4]](diffhunk://#diff-86a2cad19b3ccdaea0315bcb7c7b5c9b3a096e1b4153628c69863532a4fb47cfL54-R54) [[5]](diffhunk://#diff-872ee06703cbead1bb458977a415e4d524bf4e870380a9ef6d3d0e90ecfc284bL623-R623)
* Community Showcase: Unified padding in both the main section and its skeleton loader for better consistency. [[1]](diffhunk://#diff-b0fad5c63692ac8021325ed77f7bdc8e12a8d72273678b4180b98eabff6ec1fbL35-R35) [[2]](diffhunk://#diff-5b87333d3fd2f0f20f9c86706fcda97b2351039a3402d293537e99c4f9744f40L177-R177)
* Events and ID sections: Adjusted padding for `EventsSection` and `IdSection` to align with the new layout standards. [[1]](diffhunk://#diff-cf49241e5c7d96da74e80d33f5dbf3e9a32fdefbbca81de70ed9df04d22d44d6L14-R14) [[2]](diffhunk://#diff-f1aff8c8ab06ff98c1ac6e8032517009c6253925716372d3912aaa87b9c9ebbfL11-R11)

Closes #832 