### PR TITLE
fix(nexus-web): resolve team slug aliases and update members data structure

### DIFF
--- a/apps/nexus-web/src/features/about/components/TeamSection.tsx
+++ b/apps/nexus-web/src/features/about/components/TeamSection.tsx
@@ -603,7 +603,7 @@ export function TeamSection() {
     ),
     "internet-of-things": (
       <div className="flex flex-wrap justify-center gap-4 lg:gap-6 mt-10 lg:mt-15">
-        {TEAM_MEMBERS_BY_SLUG["internet-of-things"].map((member) => (
+        {(TEAM_MEMBERS_BY_SLUG["internet-of-things"] ?? TEAM_MEMBERS_BY_SLUG.iot ?? []).map((member) => (
           <TeamCard
             key={member.name}
             name={member.name}

--- a/apps/nexus-web/src/features/products/components/team-structure-section/TeamLeadsGrid.tsx
+++ b/apps/nexus-web/src/features/products/components/team-structure-section/TeamLeadsGrid.tsx
@@ -5,8 +5,13 @@ interface TeamLeadsGridProps {
   teamSlug: string;
 }
 
+const TEAM_SLUG_ALIASES: Record<string, string> = {
+  executives: "tech-executives",
+};
+
 export function TeamLeadsGrid({ teamSlug }: TeamLeadsGridProps) {
-  const members = TEAM_MEMBERS_BY_SLUG[teamSlug] ?? [];
+  const resolvedTeamSlug = TEAM_SLUG_ALIASES[teamSlug] ?? teamSlug;
+  const members = TEAM_MEMBERS_BY_SLUG[resolvedTeamSlug] ?? [];
 
   return (
     <Stack gap="xl" className="mt-16">

--- a/apps/nexus-web/src/features/products/components/team-structure-section/team-members.data.ts
+++ b/apps/nexus-web/src/features/products/components/team-structure-section/team-members.data.ts
@@ -967,3 +967,6 @@ export const TEAM_MEMBERS_BY_SLUG: Record<string, TeamMember[]> = {
     },
   ],
 };
+
+// Keep legacy slug compatibility for About Team section and older links.
+TEAM_MEMBERS_BY_SLUG["internet-of-things"] = TEAM_MEMBERS_BY_SLUG.iot;

--- a/apps/nexus-web/src/features/products/components/team-structure-section/team-members.data.ts
+++ b/apps/nexus-web/src/features/products/components/team-structure-section/team-members.data.ts
@@ -255,7 +255,7 @@ export const TEAM_MEMBERS_BY_SLUG: Record<string, TeamMember[]> = {
       },
     },
   ],
-  "internet-of-things": [
+  iot: [
     {
       name: "Daniel Rein Cosare",
       role: "IoT Lead",


### PR DESCRIPTION
This pull request updates how team member data accessed and displayed, primarily to support legacy slugs and improve maintainability. The main changes include renaming the "internet-of-things" team to "iot" in the data, adding compatibility for old slugs, and introducing a slug alias system for team leads. Below are the most important changes:

**Team member data structure and legacy compatibility:**

* Renamed the team key from `"internet-of-things"` to `"iot"` in `TEAM_MEMBERS_BY_SLUG` and added a legacy mapping so that `"internet-of-things"` still resolves to the new `"iot"` entry for backward compatibility. [[1]](diffhunk://#diff-5d43d9d1ed28f9ce2f26b7f7f5cb05e11724b80796631b791dba378853172e95L258-R258) [[2]](diffhunk://#diff-5d43d9d1ed28f9ce2f26b7f7f5cb05e11724b80796631b791dba378853172e95R970-R972)

**Component updates for legacy and alias support:**

* Updated the `TeamSection` component to look up team members using the `"internet-of-things"` slug, but fall back to `"iot"` if needed, ensuring older links or usages remain functional.
* Added a `TEAM_SLUG_ALIASES` mapping in `TeamLeadsGrid` to resolve legacy or alternate slugs (e.g., mapping `"executives"` to `"tech-executives"`), and updated the component to use the resolved slug for member lookup.

closes #917 