### PR TITLE
fix(nexus-web): update team members resolution logic and add legacy slug compatibility for executives

### DIFF
--- a/apps/nexus-web/src/features/products/components/team-structure-section/TeamLeadsGrid.tsx
+++ b/apps/nexus-web/src/features/products/components/team-structure-section/TeamLeadsGrid.tsx
@@ -11,7 +11,10 @@ const TEAM_SLUG_ALIASES: Record<string, string> = {
 
 export function TeamLeadsGrid({ teamSlug }: TeamLeadsGridProps) {
   const resolvedTeamSlug = TEAM_SLUG_ALIASES[teamSlug] ?? teamSlug;
-  const members = TEAM_MEMBERS_BY_SLUG[resolvedTeamSlug] ?? [];
+  const members =
+    TEAM_MEMBERS_BY_SLUG[teamSlug] ??
+    TEAM_MEMBERS_BY_SLUG[resolvedTeamSlug] ??
+    [];
 
   return (
     <Stack gap="xl" className="mt-16">

--- a/apps/nexus-web/src/features/products/components/team-structure-section/team-members.data.ts
+++ b/apps/nexus-web/src/features/products/components/team-structure-section/team-members.data.ts
@@ -970,3 +970,4 @@ export const TEAM_MEMBERS_BY_SLUG: Record<string, TeamMember[]> = {
 
 // Keep legacy slug compatibility for About Team section and older links.
 TEAM_MEMBERS_BY_SLUG["internet-of-things"] = TEAM_MEMBERS_BY_SLUG.iot;
+TEAM_MEMBERS_BY_SLUG.executives = TEAM_MEMBERS_BY_SLUG["tech-executives"];


### PR DESCRIPTION
This pull request improves the handling of team member lookups in the team structure section to better support legacy and alternate team slugs. The main changes ensure that both the original and resolved slugs are checked, and that the `executives` slug is properly aliased to `tech-executives`.

**Team member lookup improvements:**

* Updated `TeamLeadsGrid` to first check for team members using the original `teamSlug`, then fall back to the resolved alias, ensuring better compatibility with legacy and alternate slugs.

**Legacy slug compatibility:**

* Added an alias so that `TEAM_MEMBERS_BY_SLUG.executives` points to `TEAM_MEMBERS_BY_SLUG["tech-executives"]`, supporting older links and references.

closes #918 