### PR TITLE
fix: resolve env issues for the GCS bucket

### DIFF
--- a/.github/workflows/ci.deploy.yml
+++ b/.github/workflows/ci.deploy.yml
@@ -106,10 +106,12 @@ jobs:
             ZEPTOMAIL_FROM_ADDRESS=${{ secrets.ZEPTOMAIL_FROM_ADDRESS }},\
             ZEPTOMAIL_FROM_NAME=${{ secrets.ZEPTOMAIL_FROM_NAME }},\
             HIDE_API_DOCS=${{ vars.HIDE_API_DOCS || secrets.HIDE_API_DOCS || 'false' }},\
-            GCS_PROJECT_ID=${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'gdgpup-484914' }},\
-            GCS_BUCKET_NAME=${{ vars.GCS_BUCKET_NAME || 'gdgpuporg' }},\
+            FILE_STORAGE_MAIN_PROVIDER=${{ vars.FILE_STORAGE_MAIN_PROVIDER || 'gcs' }},\
+            GCP_PROJECT_ID=${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'gdgpup-484914' }},\
+            GCS_BUCKET_NAME=${{ vars.GCS_BUCKET_NAME || 'gdgpuporgstorage' }},\
             GCS_PREVIEW_URL_TYPE=${{ vars.GCS_PREVIEW_URL_TYPE || 'signed' }},\
             GCS_SIGNED_URL_EXPIRES_SECONDS=${{ vars.GCS_SIGNED_URL_EXPIRES_SECONDS || '900' }},\
             GCS_MAKE_PUBLIC_ON_UPLOAD=${{ vars.GCS_MAKE_PUBLIC_ON_UPLOAD || 'false' }},\
             GCS_PUBLIC_BASE_URL=${{ vars.GCS_PUBLIC_BASE_URL || 'https://storage.googleapis.com' }},\
-            GCS_UPLOAD_PREFIX=${{ vars.GCS_UPLOAD_PREFIX || 'local-test' }}"
+            GCS_UPLOAD_PREFIX=${{ vars.GCS_UPLOAD_PREFIX || 'uploads' }},\
+            GCS_CREDENTIALS_BASE64=${{ secrets.GCS_CREDENTIALS_BASE64 }}"

--- a/apps/nexus-api/src/v1/lib/gcsStorage/gcsStorageConfigs.ts
+++ b/apps/nexus-api/src/v1/lib/gcsStorage/gcsStorageConfigs.ts
@@ -61,4 +61,5 @@ export const gcsStorageConfigs = {
       900,
     ),
     makePublicOnUpload: process.env.GCS_MAKE_PUBLIC_ON_UPLOAD === "true",
+    credentialsBase64: process.env.GCS_CREDENTIALS_BASE64 || "",
   }

--- a/apps/nexus-api/src/v1/modules/filesModule/infrastructure/GCPFileStorage.ts
+++ b/apps/nexus-api/src/v1/modules/filesModule/infrastructure/GCPFileStorage.ts
@@ -20,7 +20,14 @@ export class GCPFileStorage implements IFileStorage {
       storageOptions.projectId = configs.gcp.projectId;
     }
 
-    if (configs.gcp.credentialsFile) {
+    if (configs.gcp.credentialsBase64) {
+      try {
+        const decoded = Buffer.from(configs.gcp.credentialsBase64, "base64").toString("utf-8");
+        storageOptions.credentials = JSON.parse(decoded);
+      } catch (error) {
+        console.error("Failed to parse GCS_CREDENTIALS_BASE64 as JSON:", error);
+      }
+    } else if (configs.gcp.credentialsFile) {
       storageOptions.keyFilename = configs.gcp.credentialsFile;
     }
 


### PR DESCRIPTION
Closes #946 

This pull request updates the GCS (Google Cloud Storage) configuration and authentication flow to support base64-encoded credentials, improving deployment flexibility and security. The main changes involve updating the CI/CD workflow to pass a new `GCS_CREDENTIALS_BASE64` secret, extending the GCS storage config to read this value, and modifying the GCP file storage implementation to decode and use these credentials if provided.

**CI/CD and Environment Variable Updates:**
- [`.github/workflows/ci.deploy.yml`](diffhunk://#diff-1d3249589956421f0b7892348807f0472346962ae03c73b3c049f714e8b72367L109-R117): Added support for a new `GCS_CREDENTIALS_BASE64` environment variable for deployments, updated the bucket name default, and introduced a `FILE_STORAGE_MAIN_PROVIDER` variable.

**GCS Storage Configuration:**
- [`apps/nexus-api/src/v1/lib/gcsStorage/gcsStorageConfigs.ts`](diffhunk://#diff-b1cbd18eab098b69b3ad1d02bcb1da57a04910bba23fb1e3a45fb83c20dabe67R64): Extended GCS storage configs to include a `credentialsBase64` field, sourced from the environment.

**GCP File Storage Implementation:**
- [`apps/nexus-api/src/v1/modules/filesModule/infrastructure/GCPFileStorage.ts`](diffhunk://#diff-cf42f3ae5e876a5f7c3c1da5d09ef857bf28753d522823d1590817fcd134ebf1L23-R30): Updated the logic to decode and parse credentials from `credentialsBase64` if present, falling back to file-based credentials otherwise, with error handling for invalid input.