### PR TITLE
enhance: add delete button for the project cards

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/ProjectCard.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/ProjectCard.tsx
@@ -2,7 +2,7 @@
 import { Text } from "@packages/spark-ui";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 import type { Ref } from "react";
-import { MdDragIndicator } from "react-icons/md";
+import { MdDragIndicator, MdDeleteOutline } from "react-icons/md";
 import { MdCalendarMonth } from "react-icons/md";
 import Link from "next/link";
 import { editIcon } from "../icons/editIcon";
@@ -26,6 +26,7 @@ type ProjectLike = {
 type ProjectCardProps = {
   project: ProjectLike;
   onEdit?: () => void;
+  onDelete?: () => void;
   showDragHandle?: boolean;
   dragHandleRef?: Ref<HTMLButtonElement>;
   dragHandleAttributes?: DraggableAttributes;
@@ -157,6 +158,7 @@ const normalizeProjectImages = (project: ProjectLike): string[] => {
 export function ProjectCard({
   project,
   onEdit,
+  onDelete,
   showDragHandle = false,
   dragHandleRef,
   dragHandleAttributes,
@@ -258,6 +260,18 @@ export function ProjectCard({
               title="Edit project"
             >
               {editIcon}
+            </button>
+          )}
+
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-white/30 text-white transition hover:border-red-500/60 hover:bg-red-500/10 hover:text-red-400"
+              aria-label="Delete project"
+              title="Delete project"
+            >
+              <MdDeleteOutline className="h-4 w-4" />
             </button>
           )}
         </div>

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/SortableProjectCardItem.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/SortableProjectCardItem.tsx
@@ -9,6 +9,7 @@ type SortableProjectCardItemProps = {
   id: string;
   project: any;
   onEdit?: () => void;
+  onDelete?: () => void;
   sortingDisabled?: boolean;
   handleDisabled?: boolean;
   isDropTarget?: boolean;
@@ -21,6 +22,7 @@ export function SortableProjectCardItem({
   id,
   project,
   onEdit,
+  onDelete,
   sortingDisabled = false,
   handleDisabled = false,
   isDropTarget = false,
@@ -63,6 +65,7 @@ export function SortableProjectCardItem({
       <ProjectCard
         project={project}
         onEdit={readOnly ? undefined : onEdit}
+        onDelete={readOnly ? undefined : onDelete}
         showDragHandle={!readOnly}
         dragHandleRef={setActivatorNodeRef}
         dragHandleAttributes={attributes}

--- a/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
@@ -288,6 +288,11 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
     setIsEditModalOpen(true);
   };
 
+  const handleDeleteDirectly = (project: any) => {
+    setEditingProject(toProjectFormState(project));
+    setIsDeleteConfirmOpen(true);
+  };
+
   const handleDeleteCurrentProject = () => {
     if (!editingProject.id) {
       return;
@@ -538,6 +543,7 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
                       ? `/sparkmates/${profile.gdgId}/projects/${project.id}`
                       : `/sparkmates/me/projects/${project.id}`}
                     onEdit={() => handleOpenEditProjectModal(project)}
+                    onDelete={() => handleDeleteDirectly(project)}
                     sortingDisabled={reorderProjects.isPending}
                     handleDisabled={reorderProjects.isPending}
                     readOnly={readOnly}


### PR DESCRIPTION
This pull request adds a delete button to each project card in the Sparkmates owner view, allowing users to trigger project deletion directly from the UI. The changes ensure that the delete functionality is properly threaded through the relevant components and handlers.

**Project delete functionality:**

* Added an optional `onDelete` prop to `ProjectCard` and rendered a delete button (with `MdDeleteOutline` icon) when provided. [[1]](diffhunk://#diff-e5edba71c714f724e8fe2756400d0083ee4b62c38c966d03a4bb987571fb14c5L5-R5) [[2]](diffhunk://#diff-e5edba71c714f724e8fe2756400d0083ee4b62c38c966d03a4bb987571fb14c5R29) [[3]](diffhunk://#diff-e5edba71c714f724e8fe2756400d0083ee4b62c38c966d03a4bb987571fb14c5R161) [[4]](diffhunk://#diff-e5edba71c714f724e8fe2756400d0083ee4b62c38c966d03a4bb987571fb14c5R265-R276)
* Updated `SortableProjectCardItem` to accept and pass through the `onDelete` prop to `ProjectCard`, respecting the `readOnly` state. [[1]](diffhunk://#diff-11aaa8c00b9ccee2d6209d331bc3263cdc5d9c80bbddee3bcc8f3b682934e6f8R12) [[2]](diffhunk://#diff-11aaa8c00b9ccee2d6209d331bc3263cdc5d9c80bbddee3bcc8f3b682934e6f8R25) [[3]](diffhunk://#diff-11aaa8c00b9ccee2d6209d331bc3263cdc5d9c80bbddee3bcc8f3b682934e6f8R68)
* In `ProjectsSection`, added a `handleDeleteDirectly` handler to open the delete confirmation modal when the delete button is clicked, and passed this handler to each project card. [[1]](diffhunk://#diff-70ada52a56c11beb6ac5c6ff5c40c4ce7d847301e97219c4df2b29c21986e2adR291-R295) [[2]](diffhunk://#diff-70ada52a56c11beb6ac5c6ff5c40c4ce7d847301e97219c4df2b29c21986e2adR546)