### PR TITLE
refactor(nexus-web): update DateSelector and 'View More' text styling

### DIFF
--- a/apps/nexus-web/src/features/events/components/DateSelector.tsx
+++ b/apps/nexus-web/src/features/events/components/DateSelector.tsx
@@ -7,6 +7,7 @@ import {
   DropdownContent,
   DropdownLabel,
   Button,
+  Text,
 } from "@packages/spark-ui";
 
 const MONTHS = [
@@ -67,9 +68,15 @@ export function DateSelector({
               variant="ghost"
               className="bg-[#1a1a1a] border border-white/10 hover:bg-[#262626] h-10 md:h-12 flex items-center gap-2 px-4 md:px-5 rounded-xl group transition-all duration-200 shadow-sm"
             >
-              <span className="text-white/90 text-sm md:text-base font-bold tracking-tight">
+              <Text
+                as="span"
+                variant="body"
+                gradient="white-green"
+                weight="bold"
+                className="text-sm md:text-base tracking-tight"
+              >
                 {MONTHS[currentMonth]} {currentYear}
-              </span>
+              </Text>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"

--- a/apps/nexus-web/src/features/events/components/EventsCalendar.tsx
+++ b/apps/nexus-web/src/features/events/components/EventsCalendar.tsx
@@ -454,7 +454,7 @@ export function EventsCalendar({
                           </p>
                         )}
                         <p className="hidden md:group-hover:block text-[9px] md:text-sm leading-tight font-semibold text-black">
-                          View More →
+                          View More
                         </p>
                       </div>
                     )}


### PR DESCRIPTION
This pull request makes small UI improvements to the date selector and events calendar components. The main changes are the use of the `Text` component for consistent styling and a minor text tweak in the calendar.

UI consistency improvements:

* Replaced a `span` with the `Text` component for the month/year label in `DateSelector`, applying the `gradient="white-green"` and `weight="bold"` props for enhanced styling.
* Added the `Text` component import from `@packages/spark-ui` in `DateSelector.tsx`.

Minor text update:

* Removed the arrow symbol from the "View More →" label in the events calendar for a cleaner look.

closes #915 