### PR TITLE
refactor(nexus-web): improve bio rendering in SuggestedPeopleSection

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/sections/SuggestedPeopleSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/SuggestedPeopleSection.tsx
@@ -40,6 +40,11 @@ export const SuggestedPeopleSection = ({
     setViewingSearchResults(false);
   };
 
+  const getSuggestedBio = (bio?: string | null) => {
+    const trimmedBio = bio?.trim();
+    return trimmedBio ? trimmedBio : "No description yet.";
+  };
+
   return (
     <FadeInSection delay={0.1} className="min-w-0">
       <div className="flex w-full min-w-0 flex-wrap items-center gap-2 sm:flex-nowrap">
@@ -100,7 +105,7 @@ export const SuggestedPeopleSection = ({
                 key={member.gdgId}
                 avatarUrl={member.avatarUrl ?? undefined}
                 name={member.displayName || member.firstName || member.gdgId}
-                bio={member.bio || "---"}
+                bio={getSuggestedBio(member.bio)}
                 gdgId={member.gdgId}
               />
             ))}
@@ -122,7 +127,7 @@ export const SuggestedPeopleSection = ({
                 key={member.gdgId}
                 avatarUrl={member.avatarUrl ?? undefined}
                 name={member.displayName || member.firstName || member.gdgId}
-                bio={member.bio || "---"}
+                bio={getSuggestedBio(member.bio)}
                 gdgId={member.gdgId}
               />
             ))}


### PR DESCRIPTION
This pull request improves how user bios are displayed in the `SuggestedPeopleSection` component. Instead of showing raw or placeholder values, it introduces a helper function to provide a consistent default message when a bio is missing or empty.

Improvements to user bio display:

* Added a new helper function `getSuggestedBio` to ensure bios are trimmed and display "No description yet." when empty or missing, improving user experience and consistency. (`apps/nexus-web/src/features/sparkmates/components/sections/SuggestedPeopleSection.tsx` [apps/nexus-web/src/features/sparkmates/components/sections/SuggestedPeopleSection.tsxR43-R47](diffhunk://#diff-26ecff0954a1d4aaffe185bbdb5d12224da687ef899451387f476ae39cc53040R43-R47))
* Updated usage of the `bio` prop in the component to use `getSuggestedBio`, replacing the previous fallback of `"---"`. (`apps/nexus-web/src/features/sparkmates/components/sections/SuggestedPeopleSection.tsx` [[1]](diffhunk://#diff-26ecff0954a1d4aaffe185bbdb5d12224da687ef899451387f476ae39cc53040L103-R108) [[2]](diffhunk://#diff-26ecff0954a1d4aaffe185bbdb5d12224da687ef899451387f476ae39cc53040L125-R130)