### PR TITLE
fix(nexus-web): prevent empty state button from rendering in read-only mode

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/sections/SkillsAndLinksSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/SkillsAndLinksSection.tsx
@@ -220,7 +220,8 @@ export function SkillsAndLinksSection({
         />
       </div>
 
-      {profile.technicalSkills?.length === 0 &&
+      {!readOnly &&
+      profile.technicalSkills?.length === 0 &&
       profile.learningInterests?.length === 0 &&
       profile.toolsAndTechnologies?.length === 0 ? (
         <Button


### PR DESCRIPTION
This pull request updates the `SkillsAndLinksSection` component to improve the display logic for the "Add" button. Now, the button only appears when the section is not in read-only mode and when all relevant skill lists are empty.

Display logic update:

* The "Add" button in `SkillsAndLinksSection` will now only be shown if the component is not in read-only mode and all of `technicalSkills`, `learningInterests`, and `toolsAndTechnologies` are empty.