### PR TITLE
fix(nexus-web): reset description expansion state on projectId change

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/ProjectDetailsView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/ProjectDetailsView.tsx
@@ -324,6 +324,10 @@ export const ProjectDetailsView = ({
     };
   }, []);
 
+  useEffect(() => {
+    setIsDescriptionExpanded(false);
+  }, [projectId]);
+
   if (isLoading) {
     return <LoadingScreen message="Loading project..." />;
   }
@@ -432,10 +436,6 @@ export const ProjectDetailsView = ({
     setEditingProject(toProjectFormState(project));
     setIsEditModalOpen(true);
   };
-
-  useEffect(() => {
-    setIsDescriptionExpanded(false);
-  }, [projectId]);
 
   const handleUpdateProjectField = (
     index: number,


### PR DESCRIPTION
This pull request makes a minor update to the `ProjectDetailsView` component. The effect that resets the expanded state of the project description when the `projectId` changes has been moved to an earlier position in the file for improved code organization. No functional changes have been made.

closes #957