### PR TITLE
refactor(nexus-web): add loading state for suggested users

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/sections/SuggestedPeopleSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/SuggestedPeopleSection.tsx
@@ -8,6 +8,7 @@ import { viewIcon } from "../SparkmatesOwnerView/icons/viewIcon";
 import { useSuggestedSparkmates } from "@/features/sparkmates/hooks";
 import { UserProfile } from "@/features/sparkmates/types";
 import { useSearchMember } from "@/features/sparkmates/hooks/useSearchMember";
+import { GdgLoader } from "@/components/ui/loader";
 
 export const SuggestedPeopleSection = ({
   profile,
@@ -122,17 +123,28 @@ export const SuggestedPeopleSection = ({
 
         {!viewingSearchResults && (
           <>
-            {suggestedUsers.map((member) => (
-              <ConnectedSuggestedCard
-                key={member.gdgId}
-                avatarUrl={member.avatarUrl ?? undefined}
-                name={member.displayName || member.firstName || member.gdgId}
-                bio={getSuggestedBio(member.bio)}
-                gdgId={member.gdgId}
-              />
-            ))}
+            {isLoading ? (
+              <div className="rounded-xl border border-white/10 bg-white/5 p-5">
+                <div className="inline-flex items-center gap-2 text-[#C1C7CD]">
+                  <GdgLoader size="xs" />
+                  <Text variant="body-sm" className="text-[#C1C7CD]">
+                    Loading suggestions...
+                  </Text>
+                </div>
+              </div>
+            ) : (
+              suggestedUsers.map((member) => (
+                <ConnectedSuggestedCard
+                  key={member.gdgId}
+                  avatarUrl={member.avatarUrl ?? undefined}
+                  name={member.displayName || member.firstName || member.gdgId}
+                  bio={getSuggestedBio(member.bio)}
+                  gdgId={member.gdgId}
+                />
+              ))
+            )}
 
-            {suggestedUsers.length === 0 ? (
+            {suggestedUsers.length === 0 && !isLoading ? (
               <div className="rounded-xl border border-white/10 bg-white/5 p-5 text-center">
                 <Text variant="body-sm" className="text-[#C1C7CD]">
                   No matches found.


### PR DESCRIPTION
This pull request improves the user experience in the `SuggestedPeopleSection` by adding a loading indicator while suggested users are being fetched. Now, users will see a loader and a "Loading suggestions..." message instead of an empty state during data retrieval.

**User experience improvements:**

* Added a loading state to the `SuggestedPeopleSection` that displays a `GdgLoader` spinner and a "Loading suggestions..." message when suggestions are being fetched. This prevents showing an empty or incomplete list and provides clear feedback to the user. [[1]](diffhunk://#diff-26ecff0954a1d4aaffe185bbdb5d12224da687ef899451387f476ae39cc53040R11) [[2]](diffhunk://#diff-26ecff0954a1d4aaffe185bbdb5d12224da687ef899451387f476ae39cc53040L125-R147)
* Updated the "No matches found." message to only appear when there are no suggested users and loading has completed, avoiding confusion during loading.

closes #963 