### PR TITLE
feat(nexus-web): implement social sharing functionality and add Open Graph image generation

### DIFF
--- a/apps/nexus-web/src/app/sparkmates/[gdgId]/layout.tsx
+++ b/apps/nexus-web/src/app/sparkmates/[gdgId]/layout.tsx
@@ -1,18 +1,37 @@
 import { Metadata } from 'next';
+import { headers } from "next/headers";
 import { callEndpoint } from "@packages/typed-rest/clientReact";
 import { contract } from "@packages/nexus-api-contracts";
 import { configs } from "@/lib/constants/configs";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://gdgpup.org";
 
 type LayoutProps = {
   params: Promise<{ gdgId: string }>;
   children: React.ReactNode;
 };
 
+const getRequestSiteUrl = async () => {
+  const headerStore = await headers();
+  const forwardedProto = headerStore.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const forwardedHost = headerStore.get("x-forwarded-host")?.split(",")[0]?.trim();
+  const host = forwardedHost || headerStore.get("host") || "";
+
+  if (!host) {
+    return SITE_URL;
+  }
+
+  const protocol = forwardedProto || (host.includes("localhost") ? "http" : "https");
+  return `${protocol}://${host}`;
+};
+
 export async function generateMetadata({ params }: Omit<LayoutProps, 'children'>): Promise<Metadata> {
   const { gdgId } = await params;
+  const requestSiteUrl = await getRequestSiteUrl();
   let title = "Sparkmate | GDG PUP Nexus";
   let description = "Checkout this member's profile on GDG PUP Nexus";
-  let images: string[] = ["/og/gdgprofile.webp"];
+  const profileUrl = `${requestSiteUrl}/sparkmates/${gdgId}`;
+  const ogImageUrl = `${requestSiteUrl}/sparkmates/${gdgId}/opengraph-image`;
 
   try {
     const result = await callEndpoint(
@@ -26,11 +45,38 @@ export async function generateMetadata({ params }: Omit<LayoutProps, 'children'>
       const fullName = `${data.firstName || ''} ${data.lastName || ''}`.trim();
       title = `${fullName || data.displayName || 'Member'}'s Profile | GDG PUP`;
       description = data.bio || description;
-      if (data.avatarUrl) images = [data.avatarUrl];
     }
   } catch (error) {}
 
-  return { title, description, openGraph: { images }, twitter: { images } };
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: profileUrl,
+    },
+    openGraph: {
+      url: profileUrl,
+      type: "profile",
+      siteName: "GDG PUP Nexus",
+      locale: "en_US",
+      title,
+      description,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: `${title} OG Image`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImageUrl],
+    },
+  };
 }
 
 export default function SparkmatesLayout({ children }: { children: React.ReactNode }) {

--- a/apps/nexus-web/src/app/sparkmates/[gdgId]/opengraph-image.tsx
+++ b/apps/nexus-web/src/app/sparkmates/[gdgId]/opengraph-image.tsx
@@ -1,0 +1,211 @@
+import { ImageResponse } from "next/og";
+import { callEndpoint } from "@packages/typed-rest/clientReact";
+import { contract } from "@packages/nexus-api-contracts";
+import { configs } from "@/lib/constants/configs";
+
+export const runtime = "nodejs";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+type Params = {
+  params: Promise<{ gdgId: string }>;
+};
+
+export default async function Image({ params }: Params) {
+  const { gdgId } = await params;
+
+  let displayName = "Sparkmate";
+  let avatarUrl: string | null = null;
+  let teamBadge = "Community";
+
+  const toAbsoluteAvatarUrl = (value: string | null | undefined) => {
+    if (!value) {
+      return null;
+    }
+
+    if (/^https?:\/\//i.test(value) || value.startsWith("data:") || value.startsWith("blob:")) {
+      return value;
+    }
+
+    if (value.startsWith("//")) {
+      return `https:${value}`;
+    }
+
+    const normalized = value.startsWith("/") ? value : `/${value}`;
+    return `${configs.nexusApiBaseUrl}${normalized}`;
+  };
+
+  try {
+    const result = await callEndpoint(
+      configs.nexusApiBaseUrl,
+      contract.api.v1.gdgmembers.gdgId.GET,
+      { params: { gdgId } },
+    );
+
+    if (result.status === 200 && result.body?.data) {
+      const data = result.body.data;
+      const fullName = `${data.firstName || ""} ${data.lastName || ""}`.trim();
+      displayName = data.displayName || fullName || displayName;
+      avatarUrl = toAbsoluteAvatarUrl(data.avatarUrl || null);
+      teamBadge = data.department?.trim() || teamBadge;
+    }
+  } catch {
+    // Fall back to defaults if profile fetch fails.
+  }
+
+  const initials = displayName
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((value) => value[0]?.toUpperCase() || "")
+    .join("") || "SP";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "linear-gradient(135deg, #010B1D 0%, #13294B 45%, #1B3F73 100%)",
+          color: "#FFFFFF",
+          padding: "56px",
+          fontFamily: "Arial, sans-serif",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "radial-gradient(circle at 20% 15%, rgba(249,171,0,0.28), transparent 28%), radial-gradient(circle at 85% 85%, rgba(52,168,83,0.24), transparent 30%)",
+          }}
+        />
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            fontSize: "28px",
+            fontWeight: 700,
+            opacity: 0.95,
+            zIndex: 1,
+          }}
+        >
+          <span>GDG PUP NEXUS</span>
+          <span style={{ opacity: 0.75 }}>|</span>
+          <span style={{ opacity: 0.85 }}>Sparkmates</span>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "28px",
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              width: "220px",
+              height: "220px",
+              borderRadius: "999px",
+              overflow: "hidden",
+              border: "4px solid rgba(255,255,255,0.42)",
+              background: "linear-gradient(135deg, #2B7FFF 0%, #34A853 50%, #F9AB00 100%)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              boxShadow: "0 20px 45px rgba(0,0,0,0.35)",
+              flexShrink: 0,
+            }}
+          >
+            {avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt={`${displayName} avatar`}
+                width={220}
+                height={220}
+                style={{ objectFit: "cover", width: "100%", height: "100%" }}
+              />
+            ) : (
+              <div
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "84px",
+                  fontWeight: 800,
+                  color: "#FFFFFF",
+                  background:
+                    "linear-gradient(145deg, rgba(66,133,244,0.9) 0%, rgba(52,168,83,0.82) 60%, rgba(249,171,0,0.85) 100%)",
+                }}
+              >
+                {initials}
+              </div>
+            )}
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "16px", flex: 1 }}>
+            <div style={{ fontSize: "64px", fontWeight: 800, lineHeight: 1.05 }}>
+              {displayName}
+            </div>
+            <div style={{ fontSize: "30px", opacity: 0.95 }}>
+              Public Profile Preview
+            </div>
+            <div
+              style={{
+                alignSelf: "flex-start",
+                fontSize: "22px",
+                fontWeight: 700,
+                color: "#E8F1FF",
+                border: "1px solid rgba(255,255,255,0.28)",
+                borderRadius: "999px",
+                padding: "10px 18px",
+                background: "rgba(10, 25, 54, 0.55)",
+              }}
+            >
+              Team: {teamBadge}
+            </div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontSize: "34px",
+              fontWeight: 700,
+              letterSpacing: "0.04em",
+              color: "#A9D1FF",
+            }}
+          >
+            {gdgId}
+          </div>
+          <div style={{ fontSize: "24px", opacity: 0.9 }}>
+            sparkmates/{gdgId}
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  );
+}

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
@@ -5,6 +5,7 @@ import { CosmosParticles, LoadingScreen } from "@/components/shared";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
+import { toast } from "react-toastify";
 import { useSparkmateProfile } from "../../hooks";
 import { SparkmatesSource } from "../../types";
 import { useUpdateSparkmateProfile } from "../../hooks/useUpdateSparkmateProfile";
@@ -33,6 +34,20 @@ const SECTION_LABELS: Record<SparkmatesSectionId, string> = {
   projects: "Projects",
   gdgImpact: "GDG Impact",
   badges: "Badges",
+};
+
+type SharePlatform = "facebook" | "instagram" | "linkedin";
+
+const SHARE_PLATFORM_LABELS: Record<SharePlatform, string> = {
+  facebook: "Facebook",
+  instagram: "Instagram",
+  linkedin: "LinkedIn",
+};
+
+const SHARE_BUTTON_CLASSNAMES: Record<SharePlatform, string> = {
+  facebook: "px-3 py-1 text-white border border-[#4267B2]/50 bg-[#4267B2]/20 hover:bg-[#4267B2]/30",
+  instagram: "px-3 py-1 text-white border border-[#E4405F]/50 bg-[#E4405F]/20 hover:bg-[#E4405F]/30",
+  linkedin: "px-3 py-1 text-white border border-[#0A66C2]/50 bg-[#0A66C2]/20 hover:bg-[#0A66C2]/30",
 };
 
 const areSectionOrdersEqual = (
@@ -99,11 +114,28 @@ export function ProfileOwnerView({
   gdgId: string;
   source: SparkmatesSource;
 }) {
+  const shareBaseUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim()
+    || (typeof window !== "undefined" ? window.location.origin : "https://gdgpup.org");
+
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [isPreviewClosing, setIsPreviewClosing] = useState(false);
+  const [sharePrompt, setSharePrompt] = useState<{
+    isOpen: boolean;
+    platform: SharePlatform | null;
+    shareUrl: string;
+    isClipboardCopied: boolean;
+    clipboardText: string;
+  }>({
+    isOpen: false,
+    platform: null,
+    shareUrl: "",
+    isClipboardCopied: false,
+    clipboardText: "",
+  });
   const [previewTilt, setPreviewTilt] = useState({ rotateX: 0, rotateY: 0 });
   const [isDesktopReorderMode, setIsDesktopReorderMode] = useState(false);
   const [isMobileReorderModalOpen, setIsMobileReorderModalOpen] = useState(false);
+  const [isSharing, setIsSharing] = useState(false);
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null);
   const [mobileDraggingIndex, setMobileDraggingIndex] = useState<number | null>(null);
@@ -221,6 +253,145 @@ export function ProfileOwnerView({
         },
       },
     );
+  };
+
+  const getShareUrl = () => {
+    return `${shareBaseUrl}/sparkmates/${effectiveGdgId}`;
+  };
+
+  const getShareCaption = () => {
+    const displayName = userprofile?.displayName?.trim()
+      || `${userprofile?.firstName || ""} ${userprofile?.lastName || ""}`.trim()
+      || effectiveGdgId;
+    const team = userprofile?.department?.trim() || "Community";
+    const teamTag = team.replace(/[^a-zA-Z0-9]/g, "");
+    const shareUrl = getShareUrl();
+
+    return `Meet ${displayName} from GDG PUP Nexus on Sparkmates.\nExplore projects, skills, and community impact here:\n${shareUrl}\n\n#GDGPUP #Sparkmates #GDGPUPNexus #DevCommunity #CampusTech #${teamTag} #${effectiveGdgId.replace(/[^a-zA-Z0-9]/g, "")}`;
+  };
+
+  const getFacebookQuote = () => {
+    const displayName = userprofile?.displayName?.trim()
+      || `${userprofile?.firstName || ""} ${userprofile?.lastName || ""}`.trim()
+      || effectiveGdgId;
+    const facebookProfileUrl = getShareUrl();
+
+    return `Meet ${displayName} on Sparkmates: ${facebookProfileUrl} #GDGPUP #Sparkmates`;
+  };
+
+  const getLinkedInCaption = () => {
+    return getShareUrl();
+  };
+
+  const getInstagramCaption = () => {
+    return getShareUrl();
+  };
+
+  const copyTextToClipboard = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+  };
+
+  const openShareWindow = (url: string) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.open(
+      url,
+      "_blank",
+      "noopener,noreferrer,width=620,height=720",
+    );
+  };
+
+  const closeSharePrompt = () => {
+    setSharePrompt({
+      isOpen: false,
+      platform: null,
+      shareUrl: "",
+      isClipboardCopied: false,
+      clipboardText: "",
+    });
+  };
+
+  const openSharePrompt = async (
+    platform: SharePlatform,
+    shareWindowUrl: string,
+    clipboardText: string,
+  ) => {
+    setIsSharing(true);
+
+    let copied = false;
+    try {
+      await copyTextToClipboard(clipboardText);
+      copied = true;
+    } catch {
+      copied = false;
+    } finally {
+      setIsSharing(false);
+    }
+
+    setSharePrompt({
+      isOpen: true,
+      platform,
+      shareUrl: shareWindowUrl,
+      isClipboardCopied: copied,
+      clipboardText,
+    });
+  };
+
+  const handleCopyPromptText = async () => {
+    if (!sharePrompt.clipboardText) {
+      return;
+    }
+
+    try {
+      await copyTextToClipboard(sharePrompt.clipboardText);
+      setSharePrompt((previous) => ({
+        ...previous,
+        isClipboardCopied: true,
+      }));
+      toast.success("Copied to clipboard.");
+    } catch {
+      toast.error("Unable to copy clipboard in this browser.");
+    }
+  };
+
+  const handleContinueShare = () => {
+    if (!sharePrompt.shareUrl) {
+      return;
+    }
+
+    openShareWindow(sharePrompt.shareUrl);
+    closeSharePrompt();
+  };
+
+  const handleShare = async (platform: SharePlatform) => {
+    const shareUrl = getShareUrl();
+    if (!shareUrl) {
+      toast.error("Unable to build share link.");
+      return;
+    }
+
+    if (platform === "facebook") {
+      const quote = getFacebookQuote();
+      const shareUrlForFacebook = `${shareUrl}?share=facebook`;
+      const searchParams = new URLSearchParams({
+        u: shareUrlForFacebook,
+        quote,
+        hashtag: "#GDGPUP",
+      });
+      const facebookShareUrl = `https://www.facebook.com/sharer/sharer.php?${searchParams.toString()}`;
+      await openSharePrompt("facebook", facebookShareUrl, getShareCaption());
+      return;
+    }
+
+    if (platform === "linkedin") {
+      const linkedInShareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+      await openSharePrompt("linkedin", linkedInShareUrl, getLinkedInCaption());
+      return;
+    }
+
+    await openSharePrompt("instagram", "https://www.instagram.com/", getInstagramCaption());
   };
 
   const handleDropSection = (targetIndex: number) => {
@@ -371,7 +542,7 @@ export function ProfileOwnerView({
               <Text variant="heading-5" className="text-white">
                 My Portfolio
               </Text>
-              <div className="flex gap-2">
+              <div className="flex gap-2" role="group" aria-label="Share profile">
                 <Link prefetch={false} href="/sparkmates/me/analytics">
                   <Button
                     variant="colored"
@@ -382,6 +553,22 @@ export function ProfileOwnerView({
                     Analytics
                   </Button>
                 </Link>
+                {(["facebook", "instagram", "linkedin"] as SharePlatform[]).map((platform) => (
+                  <Button
+                    key={platform}
+                    variant="default"
+                    size="sm"
+                    className={SHARE_BUTTON_CLASSNAMES[platform]}
+                    title={`Share on ${SHARE_PLATFORM_LABELS[platform]}`}
+                    aria-label={`Share on ${SHARE_PLATFORM_LABELS[platform]}`}
+                    onClick={() => {
+                      void handleShare(platform);
+                    }}
+                    disabled={isSharing}
+                  >
+                    {SHARE_PLATFORM_LABELS[platform]}
+                  </Button>
+                ))}
                 <Button
                   variant="default"
                   size="sm"
@@ -414,9 +601,9 @@ export function ProfileOwnerView({
                   animate={{ opacity: 1, y: 0, scale: 1 }}
                   exit={{ opacity: 0, y: -24, scale: 0.985 }}
                   transition={{ duration: 0.28, ease: "easeOut" }}
-                  className="fixed left-0 right-0 top-0 z-[60] hidden md:px-16 md:pt-10 sm:block pointer-events-none"
+                  className="fixed left-0 right-0 top-0 z-60 hidden md:px-16 md:pt-10 sm:block pointer-events-none"
                 >
-                  <div className="pointer-events-auto mx-auto h-22 max-w-7xl md:rounded-[1.875rem] px-8 md:px-12 lg:px-20 flex items-center shadow-[0px_4px_4px_0px_#00000040,0px_4px_46.1px_0px_#00000040,0px_4px_36px_0px_#FFFFFF40_inset] bg-black/80 backdrop-blur-xl relative isolate before:content-[''] before:absolute before:-inset-px before:rounded-[inherit] before:p-[2px] before:bg-size-[100%_100%] before:pointer-events-none before:z-[-1] before:mask-[linear-gradient(#fff_0_0),linear-gradient(#fff_0_0)] before:[mask-origin:content-box,border-box] before:[mask-clip:content-box,border-box] before:mask-exclude before:bg-[linear-gradient(to_bottom_right,#FB2C36_0%,#F0B100_5%,#00C950_10%,#2B7FFF_15%,#FFFFFF_50.48%,#2B7FFF_85%,#00C950_90%,#F0B100_95%,#FB2C36_100%)]">
+                  <div className="pointer-events-auto mx-auto h-22 max-w-7xl md:rounded-[1.875rem] px-8 md:px-12 lg:px-20 flex items-center shadow-[0px_4px_4px_0px_#00000040,0px_4px_46.1px_0px_#00000040,0px_4px_36px_0px_#FFFFFF40_inset] bg-black/80 backdrop-blur-xl relative isolate before:content-[''] before:absolute before:-inset-px before:rounded-[inherit] before:p-0.5 before:bg-size-[100%_100%] before:pointer-events-none before:z-[-1] before:mask-[linear-gradient(#fff_0_0),linear-gradient(#fff_0_0)] before:[mask-origin:content-box,border-box] before:[mask-clip:content-box,border-box] before:mask-exclude before:bg-[linear-gradient(to_bottom_right,#FB2C36_0%,#F0B100_5%,#00C950_10%,#2B7FFF_15%,#FFFFFF_50.48%,#2B7FFF_85%,#00C950_90%,#F0B100_95%,#FB2C36_100%)]">
                     <div className="relative flex w-full items-center justify-between gap-3">
                       <Text variant="body" className="text-white" weight="bold">
                         Reorder mode enabled: drag sections directly. Drop to save instantly.
@@ -522,13 +709,71 @@ export function ProfileOwnerView({
         </div>
 
         <Modal
+          open={sharePrompt.isOpen}
+          onOpenChange={(open) => {
+            if (open) {
+              return;
+            }
+            if (!open) {
+              closeSharePrompt();
+            }
+          }}
+          size="sm"
+          placement="center"
+          className="bg-[#081327]/95 border border-white/15 p-0 text-white"
+        >
+          <div className="w-full max-w-md px-5 py-5">
+            <Text variant="heading-6" className="text-white" weight="bold">
+              Share to {sharePrompt.platform ? SHARE_PLATFORM_LABELS[sharePrompt.platform] : "Social"}
+            </Text>
+            <Text variant="body-sm" className="mt-2 text-[#C1C7CD]">
+              {sharePrompt.isClipboardCopied
+                ? "Clipboard has been copied. Paste it in your post after the share page opens."
+                : "Unable to auto-copy clipboard in this browser. You can still continue to share."}
+            </Text>
+            <Text variant="caption" className="mt-2 text-[#A9D1FF]">
+              Tip: open the post composer, then paste from clipboard for the fastest workflow.
+            </Text>
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <Button
+                variant="default"
+                size="sm"
+                className="text-white"
+                onClick={() => {
+                  void handleCopyPromptText();
+                }}
+              >
+                Copy Again
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                className="text-white"
+                onClick={closeSharePrompt}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="colored"
+                subVariant="blue"
+                size="sm"
+                className="text-white"
+                onClick={handleContinueShare}
+              >
+                Continue
+              </Button>
+            </div>
+          </div>
+        </Modal>
+
+        <Modal
           open={isPreviewOpen}
           onOpenChange={handlePreviewOpenChange}
           size="sm"
           scrollBehavior="outside"
           placement="center"
           closeOnEsc={false}
-          className="bg-transparent border-none p-0 !shadow-none isolate w-full max-w-[410px]"
+          className="bg-transparent border-none p-0 shadow-none! isolate w-full max-w-102.5"
         >
           <div className="flex min-h-[calc(100dvh-1.5rem)] items-center justify-center px-3 py-2 sm:min-h-0 sm:px-4 sm:py-3">
             <div
@@ -578,7 +823,7 @@ export function ProfileOwnerView({
           onOpenChange={setIsMobileReorderModalOpen}
           size="sm"
           scrollBehavior="inside"
-          className="bg-transparent border-none p-0 !shadow-none isolate sm:hidden"
+          className="bg-transparent border-none p-0 shadow-none! isolate sm:hidden"
         >
           <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/90 backdrop-blur-2xl px-5 py-6 border border-white/10">
             <Text variant="heading-6" className="text-white" weight="bold">


### PR DESCRIPTION
This pull request adds social profile sharing capabilities to the Sparkmates profile owner view, improves Open Graph metadata, and introduces dynamic Open Graph image generation for member profiles. The main changes are grouped into three themes: social sharing features, Open Graph metadata and image improvements, and minor UI tweaks.

**Key changes:**

**Social sharing features:**
- Added share buttons for Facebook, Instagram, and LinkedIn on the profile owner view, allowing users to easily share their Sparkmates profile to social platforms. Each platform uses custom captions and sharing URLs. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR39-R52) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR117-R138) [[3]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR258-R396) [[4]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL374-R545) [[5]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR556-R571)
- Implemented a modal prompt that guides users through copying share captions and opening the relevant share window, with clipboard support and user feedback.
- Added toast notifications for clipboard copy success/failure. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR8) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR258-R396)

**Open Graph metadata and image improvements:**
- Updated the `generateMetadata` function for Sparkmates profiles to provide richer Open Graph and Twitter card metadata, including canonical URLs and dynamic OG image URLs. ([apps/nexus-web/src/app/sparkmates/[gdgId]/layout.tsxR2-R34](diffhunk://#diff-24f98f14328e3bf54fff0d1ae07884667650c1d394960385ad5d3c64724612c8R2-R34), [apps/nexus-web/src/app/sparkmates/[gdgId]/layout.tsxL29-R79](diffhunk://#diff-24f98f14328e3bf54fff0d1ae07884667650c1d394960385ad5d3c64724612c8L29-R79))
- Added a new API route (`opengraph-image.tsx`) that generates a dynamic Open Graph image for each member profile, showing their avatar, name, team, and GDG ID. ([apps/nexus-web/src/app/sparkmates/[gdgId]/opengraph-image.tsxR1-R211](diffhunk://#diff-b848c6b6f41d4da4c529d85f064ceed356bdcabd83aaacac0f16bd0c30dab313R1-R211))

**UI and accessibility tweaks:**
- Improved accessibility of the share button group with appropriate ARIA attributes.
- Minor modal style adjustments for consistency. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL417-R606) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL581-R826)