### PR TITLE
feat(nexus-web): add validation on add project page

### DIFF
--- a/apps/nexus-web/src/features/onboarding/components/ProjectsManager.tsx
+++ b/apps/nexus-web/src/features/onboarding/components/ProjectsManager.tsx
@@ -5,7 +5,13 @@ import { cn } from "@/lib/utils";
 
 const MAX_PROJECT_IMAGES = 4;
 
-const StyledInputContainer = ({ children, hasError }: { children: React.ReactNode; hasError?: boolean }) => (
+const StyledInputContainer = ({
+  children,
+  hasError,
+}: {
+  children: React.ReactNode;
+  hasError?: boolean;
+}) => (
   <div
     className={cn(
       "relative group w-full rounded-lg p-px focus-within:p-0.5 hover:bg-linear-to-r focus-within:bg-linear-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_16px_40px_-12px_rgba(0,0,0,0.5)] transition-all duration-300 ease-in-out",
@@ -32,7 +38,6 @@ const textareaBaseStyles =
 const dateInputStyles =
   "min-h-12.5 w-full py-3! text-white [color-scheme:dark] outline-none [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-100";
 
-
 type ProjectErrors = {
   title?: string;
   description?: string;
@@ -41,7 +46,11 @@ type ProjectErrors = {
 
 type ProjectsManagerProps = {
   projects: ProjectFormState[];
-  updateProject: (index: number, field: keyof Omit<ProjectFormState, "id">, value: string | File | null) => void;
+  updateProject: (
+    index: number,
+    field: keyof Omit<ProjectFormState, "id">,
+    value: string | File | null,
+  ) => void;
   addProject: () => void;
   removeProject: (index: number) => void;
   singleProjectMode?: boolean;
@@ -105,7 +114,9 @@ const LocalImagePreview = ({
       >
         X
       </button>
-      <div className="truncate px-2 py-1 text-[11px] text-zinc-300">{file.name}</div>
+      <div className="truncate px-2 py-1 text-[11px] text-zinc-300">
+        {file.name}
+      </div>
     </div>
   );
 };
@@ -146,7 +157,9 @@ const UploadedImagePreview = ({
           X
         </button>
       )}
-      <div className="truncate px-2 py-1 text-[11px] text-zinc-400">Uploaded</div>
+      <div className="truncate px-2 py-1 text-[11px] text-zinc-400">
+        Uploaded
+      </div>
     </div>
   );
 };
@@ -156,9 +169,11 @@ const getExistingProjectImages = (project: ProjectFormState): string[] => {
     return project.imageUrls;
   }
 
-  return [project.mainImageUrl, project.secondaryImageUrl, project.tertiaryImageUrl].filter(
-    (image): image is string => Boolean(image),
-  );
+  return [
+    project.mainImageUrl,
+    project.secondaryImageUrl,
+    project.tertiaryImageUrl,
+  ].filter((image): image is string => Boolean(image));
 };
 
 export function ProjectsManager({
@@ -192,210 +207,270 @@ export function ProjectsManager({
           const projectErrors = errors?.[index];
 
           return (
-          <div
-            key={`${project.id ?? "new"}-${index}`}
-            className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4 space-y-3"
-          >
-            <div className="flex justify-between items-center gap-3">
-              <p className="text-sm font-medium text-zinc-300">
-                {singleProjectMode ? "Project" : `Project ${index + 1}`}
-              </p>
-              {!singleProjectMode && (
-                <button
-                  type="button"
-                  onClick={() => removeProject(index)}
-                  className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 transition-colors"
-                >
-                  Remove
-                </button>
-              )}
-            </div>
+            <div
+              key={`${project.id ?? "new"}-${index}`}
+              className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4 space-y-3"
+            >
+              <div className="flex justify-between items-center gap-3">
+                <p className="text-sm font-medium text-zinc-300">
+                  {singleProjectMode ? "Project" : `Project ${index + 1}`}
+                </p>
+                {!singleProjectMode && (
+                  <button
+                    type="button"
+                    onClick={() => removeProject(index)}
+                    className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 transition-colors"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
 
-            {/* Title */}
-            <div>
-              <label className="block text-xs text-zinc-400 mb-1">
-                Title<RequiredAsterisk />
-              </label>
-              <StyledInputContainer hasError={!!projectErrors?.title}>
-                <Input
-                  value={project.title}
-                  onChange={(event) => updateProject(index, "title", event.target.value)}
-                  placeholder="e.g. GDG PUP Website Redesign"
-                  containerClassName={inputBaseStyles}
-                  className="text-white! py-3"
-                />
-              </StyledInputContainer>
-              <ErrorMessage message={projectErrors?.title} />
-            </div>
-
-            {/* Dates */}
-            <div className="grid gap-3 sm:grid-cols-2">
+              {/* Title */}
               <div>
                 <label className="block text-xs text-zinc-400 mb-1">
-                  Start Date<RequiredAsterisk />
+                  Title
+                  <RequiredAsterisk />
                 </label>
-                <StyledInputContainer hasError={!!projectErrors?.startDate}>
-                  <input
-                    type="date"
-                    value={project.startDate}
-                    onChange={(event) => updateProject(index, "startDate", event.target.value)}
-                    className={cn(inputBaseStyles, dateInputStyles)}
+                <StyledInputContainer hasError={!!projectErrors?.title}>
+                  <Input
+                    value={project.title}
+                    onChange={(event) =>
+                      updateProject(index, "title", event.target.value)
+                    }
+                    placeholder="Project title"
+                    containerClassName={inputBaseStyles}
+                    className="text-white! py-3"
                   />
                 </StyledInputContainer>
-                <ErrorMessage message={projectErrors?.startDate} />
+                <ErrorMessage message={projectErrors?.title} />
               </div>
+
+              {/* Dates */}
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <label className="block text-xs text-zinc-400 mb-1">
+                    Start Date
+                    <RequiredAsterisk />
+                  </label>
+                  <StyledInputContainer hasError={!!projectErrors?.startDate}>
+                    <input
+                      type="date"
+                      value={project.startDate}
+                      onChange={(event) =>
+                        updateProject(index, "startDate", event.target.value)
+                      }
+                      className={cn(inputBaseStyles, dateInputStyles)}
+                    />
+                  </StyledInputContainer>
+                  <ErrorMessage message={projectErrors?.startDate} />
+                </div>
+                <div>
+                  <label className="block text-xs text-zinc-400 mb-1">
+                    End Date
+                  </label>
+                  <StyledInputContainer>
+                    <input
+                      type="date"
+                      value={project.endDate}
+                      onChange={(event) =>
+                        updateProject(index, "endDate", event.target.value)
+                      }
+                      className={cn(inputBaseStyles, dateInputStyles)}
+                    />
+                  </StyledInputContainer>
+                </div>
+              </div>
+
+              {/* Description */}
               <div>
-                <label className="block text-xs text-zinc-400 mb-1">End Date</label>
+                <label className="block text-xs text-zinc-400 mb-1">
+                  Description
+                  <RequiredAsterisk />
+                </label>
+                <StyledInputContainer hasError={!!projectErrors?.description}>
+                  <textarea
+                    value={project.description}
+                    onChange={(event) =>
+                      updateProject(index, "description", event.target.value)
+                    }
+                    placeholder="Project description"
+                    rows={3}
+                    className={cn(textareaBaseStyles, "min-h-28 resize-y")}
+                  />
+                </StyledInputContainer>
+                <ErrorMessage message={projectErrors?.description} />
+              </div>
+
+              {/* Project Link */}
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">
+                  Project Link
+                </label>
                 <StyledInputContainer>
-                  <input
-                    type="date"
-                    value={project.endDate}
-                    onChange={(event) => updateProject(index, "endDate", event.target.value)}
-                    className={cn(inputBaseStyles, dateInputStyles)}
+                  <Input
+                    value={project.projectLink}
+                    onChange={(event) =>
+                      updateProject(index, "projectLink", event.target.value)
+                    }
+                    placeholder="https://github.com/... (optional)"
+                    containerClassName={inputBaseStyles}
+                    className="text-white! py-3"
                   />
                 </StyledInputContainer>
               </div>
-            </div>
 
-            {/* Description */}
-            <div>
-              <label className="block text-xs text-zinc-400 mb-1">
-                Description<RequiredAsterisk />
-              </label>
-              <StyledInputContainer hasError={!!projectErrors?.description}>
-                <textarea
-                  value={project.description}
-                  onChange={(event) => updateProject(index, "description", event.target.value)}
-                  placeholder="Describe what the project is about, your role, and its impact..."
-                  rows={3}
-                  className={cn(textareaBaseStyles, "min-h-28 resize-y")}
-                />
-              </StyledInputContainer>
-              <ErrorMessage message={projectErrors?.description} />
-            </div>
+              {imageInputMode === "list" ? (
+                <div className="space-y-2">
+                  <label className="block text-xs text-zinc-400">
+                    Project Images (max 4)
+                  </label>
+                  {(() => {
+                    const existingImages = getExistingProjectImages(project);
+                    const selectedFiles = project.imageFiles || [];
+                    const occupiedSlots =
+                      existingImages.length + selectedFiles.length;
+                    const remainingSlots = Math.max(
+                      0,
+                      MAX_PROJECT_IMAGES - occupiedSlots,
+                    );
+                    const uploadInputId = `project-images-${index}`;
 
-            {/* Project Link */}
-            <div>
-              <label className="block text-xs text-zinc-400 mb-1">Project Link</label>
-              <StyledInputContainer>
-                <Input
-                  value={project.projectLink}
-                  onChange={(event) => updateProject(index, "projectLink", event.target.value)}
-                  placeholder="https://github.com/... (optional)"
-                  containerClassName={inputBaseStyles}
-                  className="text-white! py-3"
-                />
-              </StyledInputContainer>
-            </div>
+                    return (
+                      <>
+                        <input
+                          id={uploadInputId}
+                          type="file"
+                          accept="image/*"
+                          multiple
+                          disabled={remainingSlots === 0}
+                          onChange={(event) => {
+                            const files = Array.from(event.target.files || []);
+                            const nextFiles = files.slice(0, remainingSlots);
+                            updateProjectImages?.(index, nextFiles, "append");
+                            event.currentTarget.value = "";
+                          }}
+                          className="hidden"
+                        />
 
-            {imageInputMode === "list" ? (
-              <div className="space-y-2">
-                <label className="block text-xs text-zinc-400">Project Images (max 4)</label>
-                {(() => {
-                  const existingImages = getExistingProjectImages(project);
-                  const selectedFiles = project.imageFiles || [];
-                  const occupiedSlots = existingImages.length + selectedFiles.length;
-                  const remainingSlots = Math.max(0, MAX_PROJECT_IMAGES - occupiedSlots);
-                  const uploadInputId = `project-images-${index}`;
+                        <label
+                          htmlFor={uploadInputId}
+                          className={cn(
+                            "flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-[#4f75b9]/70 bg-[#0a162a] px-4 py-3 text-sm font-medium text-[#d8e4ff] transition",
+                            "hover:border-[#7ba7ff] hover:bg-[#122442]",
+                            remainingSlots === 0 &&
+                              "pointer-events-none cursor-not-allowed opacity-45",
+                          )}
+                        >
+                          <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-current text-xs leading-none">
+                            +
+                          </span>
+                          <span>
+                            {remainingSlots === 0
+                              ? "Maximum of 4 images reached"
+                              : "Upload Project Images"}
+                          </span>
+                        </label>
 
-                  return (
-                    <>
-                      <input
-                        id={uploadInputId}
-                        type="file"
-                        accept="image/*"
-                        multiple
-                        disabled={remainingSlots === 0}
-                        onChange={(event) => {
-                          const files = Array.from(event.target.files || []);
-                          const nextFiles = files.slice(0, remainingSlots);
-                          updateProjectImages?.(index, nextFiles, "append");
-                          event.currentTarget.value = "";
-                        }}
-                        className="hidden"
-                      />
+                        <p className="text-[11px] text-zinc-500">
+                          Existing: {existingImages.length} · Added:{" "}
+                          {selectedFiles.length} · Remaining slots:{" "}
+                          {remainingSlots}
+                        </p>
 
-                      <label
-                        htmlFor={uploadInputId}
-                        className={cn(
-                          "flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-[#4f75b9]/70 bg-[#0a162a] px-4 py-3 text-sm font-medium text-[#d8e4ff] transition",
-                          "hover:border-[#7ba7ff] hover:bg-[#122442]",
-                          remainingSlots === 0 && "pointer-events-none cursor-not-allowed opacity-45",
+                        {(existingImages.length > 0 ||
+                          selectedFiles.length > 0) && (
+                          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                            {existingImages.map((imageUrl, imageIndex) => (
+                              <UploadedImagePreview
+                                key={`${imageUrl}-${imageIndex}`}
+                                imageUrl={imageUrl}
+                                imageIndex={imageIndex}
+                                onRemove={() =>
+                                  removeExistingProjectImage?.(
+                                    index,
+                                    imageIndex,
+                                  )
+                                }
+                              />
+                            ))}
+
+                            {selectedFiles.map((file, fileIndex) => (
+                              <LocalImagePreview
+                                key={`${file.name}-${file.lastModified}-${fileIndex}`}
+                                file={file}
+                                onRemove={() => {
+                                  const next = selectedFiles.filter(
+                                    (_, i) => i !== fileIndex,
+                                  );
+                                  updateProjectImages?.(index, next, "replace");
+                                }}
+                              />
+                            ))}
+                          </div>
                         )}
-                      >
-                        <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-current text-xs leading-none">
-                          +
-                        </span>
-                        <span>
-                          {remainingSlots === 0 ? "Maximum of 4 images reached" : "Upload Project Images"}
-                        </span>
-                      </label>
-
-                      <p className="text-[11px] text-zinc-500">
-                        Existing: {existingImages.length} · Added: {selectedFiles.length} · Remaining slots: {remainingSlots}
-                      </p>
-
-                      {(existingImages.length > 0 || selectedFiles.length > 0) && (
-                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                          {existingImages.map((imageUrl, imageIndex) => (
-                            <UploadedImagePreview
-                              key={`${imageUrl}-${imageIndex}`}
-                              imageUrl={imageUrl}
-                              imageIndex={imageIndex}
-                              onRemove={() => removeExistingProjectImage?.(index, imageIndex)}
-                            />
-                          ))}
-
-                          {selectedFiles.map((file, fileIndex) => (
-                            <LocalImagePreview
-                              key={`${file.name}-${file.lastModified}-${fileIndex}`}
-                              file={file}
-                              onRemove={() => {
-                                const next = selectedFiles.filter((_, i) => i !== fileIndex);
-                                updateProjectImages?.(index, next, "replace");
-                              }}
-                            />
-                          ))}
-                        </div>
-                      )}
-                    </>
-                  );
-                })()}
-              </div>
-            ) : (
-              <>
-                <div>
-                  <label className="text-xs text-zinc-400 block mb-2">Main Image (Optional)</label>
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(event) => updateProject(index, "mainImageFile", event.target.files?.[0] ?? null)}
-                    className="block w-full text-sm text-zinc-300 file:mr-3 file:rounded-lg file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-sm file:font-medium file:text-zinc-200 hover:file:bg-zinc-700 transition-colors"
-                  />
+                      </>
+                    );
+                  })()}
                 </div>
+              ) : (
+                <>
+                  <div>
+                    <label className="text-xs text-zinc-400 block mb-2">
+                      Main Image (Optional)
+                    </label>
+                    <input
+                      type="file"
+                      accept="image/*"
+                      onChange={(event) =>
+                        updateProject(
+                          index,
+                          "mainImageFile",
+                          event.target.files?.[0] ?? null,
+                        )
+                      }
+                      className="block w-full text-sm text-zinc-300 file:mr-3 file:rounded-lg file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-sm file:font-medium file:text-zinc-200 hover:file:bg-zinc-700 transition-colors"
+                    />
+                  </div>
 
-                <div>
-                  <label className="text-xs text-zinc-400 block mb-2">Secondary Image (Optional)</label>
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(event) => updateProject(index, "secondaryImageFile", event.target.files?.[0] ?? null)}
-                    className="block w-full text-sm text-zinc-300 file:mr-3 file:rounded-lg file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-sm file:font-medium file:text-zinc-200 hover:file:bg-zinc-700 transition-colors"
-                  />
-                </div>
+                  <div>
+                    <label className="text-xs text-zinc-400 block mb-2">
+                      Secondary Image (Optional)
+                    </label>
+                    <input
+                      type="file"
+                      accept="image/*"
+                      onChange={(event) =>
+                        updateProject(
+                          index,
+                          "secondaryImageFile",
+                          event.target.files?.[0] ?? null,
+                        )
+                      }
+                      className="block w-full text-sm text-zinc-300 file:mr-3 file:rounded-lg file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-sm file:font-medium file:text-zinc-200 hover:file:bg-zinc-700 transition-colors"
+                    />
+                  </div>
 
-                <div>
-                  <label className="text-xs text-zinc-400 block mb-2">Tertiary Image (Optional)</label>
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(event) => updateProject(index, "tertiaryImageFile", event.target.files?.[0] ?? null)}
-                    className="block w-full text-sm text-zinc-300 file:mr-3 file:rounded-lg file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-sm file:font-medium file:text-zinc-200 hover:file:bg-zinc-700 transition-colors"
-                  />
-                </div>
-              </>
-            )}
-          </div>
+                  <div>
+                    <label className="text-xs text-zinc-400 block mb-2">
+                      Tertiary Image (Optional)
+                    </label>
+                    <input
+                      type="file"
+                      accept="image/*"
+                      onChange={(event) =>
+                        updateProject(
+                          index,
+                          "tertiaryImageFile",
+                          event.target.files?.[0] ?? null,
+                        )
+                      }
+                      className="block w-full text-sm text-zinc-300 file:mr-3 file:rounded-lg file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-sm file:font-medium file:text-zinc-200 hover:file:bg-zinc-700 transition-colors"
+                    />
+                  </div>
+                </>
+              )}
+            </div>
           );
         })}
       </div>

--- a/apps/nexus-web/src/features/onboarding/components/ProjectsManager.tsx
+++ b/apps/nexus-web/src/features/onboarding/components/ProjectsManager.tsx
@@ -1,15 +1,27 @@
-import React from 'react';
+import React from "react";
 import { Input, Text } from "@packages/spark-ui";
 import { ProjectFormState } from "../types";
 import { cn } from "@/lib/utils";
 
 const MAX_PROJECT_IMAGES = 4;
 
-const StyledInputContainer = ({ children }: { children: React.ReactNode }) => (
-  <div className="relative group w-full rounded-lg p-px focus-within:p-0.5 bg-[#737373] hover:bg-linear-to-r focus-within:bg-linear-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_16px_40px_-12px_rgba(0,0,0,0.5)] transition-all duration-300 ease-in-out">
+const StyledInputContainer = ({ children, hasError }: { children: React.ReactNode; hasError?: boolean }) => (
+  <div
+    className={cn(
+      "relative group w-full rounded-lg p-px focus-within:p-0.5 hover:bg-linear-to-r focus-within:bg-linear-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_16px_40px_-12px_rgba(0,0,0,0.5)] transition-all duration-300 ease-in-out",
+      hasError ? "bg-red-500/80" : "bg-[#737373]",
+    )}
+  >
     {children}
   </div>
 );
+
+const ErrorMessage = ({ message }: { message?: string }) => {
+  if (!message) return null;
+  return <p className="mt-1 text-xs text-red-400">{message}</p>;
+};
+
+const RequiredAsterisk = () => <span className="text-red-400 ml-0.5">*</span>;
 
 const inputBaseStyles =
   "!h-auto py-2 px-3 sm:py-2.5 sm:px-4 !border-none !rounded-[7px] !ring-0 !ring-offset-0 focus-within:!ring-0 focus-within:!ring-offset-0 focus-within:!shadow-none w-full transition-colors bg-[#0a162a] group-hover:bg-[#010b1d] group-focus-within:bg-[#010b1d]";
@@ -20,6 +32,12 @@ const textareaBaseStyles =
 const dateInputStyles =
   "min-h-12.5 w-full py-3! text-white [color-scheme:dark] outline-none [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-100";
 
+
+type ProjectErrors = {
+  title?: string;
+  description?: string;
+  startDate?: string;
+};
 
 type ProjectsManagerProps = {
   projects: ProjectFormState[];
@@ -34,6 +52,8 @@ type ProjectsManagerProps = {
     mode?: "append" | "replace",
   ) => void;
   removeExistingProjectImage?: (index: number, imageIndex: number) => void;
+  /** Per-project validation errors, indexed to match the `projects` array. */
+  errors?: ProjectErrors[];
 };
 
 const LocalImagePreview = ({
@@ -150,6 +170,7 @@ export function ProjectsManager({
   imageInputMode = "list",
   updateProjectImages,
   removeExistingProjectImage,
+  errors,
 }: ProjectsManagerProps) {
   return (
     <div className="mt-6 sm:col-span-2">
@@ -167,7 +188,10 @@ export function ProjectsManager({
       </div>
 
       <div className="space-y-4">
-        {projects.map((project, index) => (
+        {projects.map((project, index) => {
+          const projectErrors = errors?.[index];
+
+          return (
           <div
             key={`${project.id ?? "new"}-${index}`}
             className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4 space-y-3"
@@ -187,56 +211,82 @@ export function ProjectsManager({
               )}
             </div>
 
-            <StyledInputContainer>
-              <Input
-                value={project.title}
-                onChange={(event) => updateProject(index, "title", event.target.value)}
-                placeholder="Project title"
-                containerClassName={inputBaseStyles}
-                className="text-white! py-3"
-              />
-            </StyledInputContainer>
-
-            <div className="grid gap-3 sm:grid-cols-2 mt-3">
-              <StyledInputContainer>
-                <input
-                  type="date"
-                  value={project.startDate}
-                  onChange={(event) => updateProject(index, "startDate", event.target.value)}
-                  className={cn(inputBaseStyles, dateInputStyles)}
+            {/* Title */}
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">
+                Title<RequiredAsterisk />
+              </label>
+              <StyledInputContainer hasError={!!projectErrors?.title}>
+                <Input
+                  value={project.title}
+                  onChange={(event) => updateProject(index, "title", event.target.value)}
+                  placeholder="e.g. GDG PUP Website Redesign"
+                  containerClassName={inputBaseStyles}
+                  className="text-white! py-3"
                 />
               </StyledInputContainer>
-              <StyledInputContainer>
-                <input
-                  type="date"
-                  value={project.endDate}
-                  onChange={(event) => updateProject(index, "endDate", event.target.value)}
-                  className={cn(inputBaseStyles, dateInputStyles)}
-                />
-              </StyledInputContainer>
+              <ErrorMessage message={projectErrors?.title} />
             </div>
 
-            <div className="mt-3">
-              <StyledInputContainer>
+            {/* Dates */}
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">
+                  Start Date<RequiredAsterisk />
+                </label>
+                <StyledInputContainer hasError={!!projectErrors?.startDate}>
+                  <input
+                    type="date"
+                    value={project.startDate}
+                    onChange={(event) => updateProject(index, "startDate", event.target.value)}
+                    className={cn(inputBaseStyles, dateInputStyles)}
+                  />
+                </StyledInputContainer>
+                <ErrorMessage message={projectErrors?.startDate} />
+              </div>
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">End Date</label>
+                <StyledInputContainer>
+                  <input
+                    type="date"
+                    value={project.endDate}
+                    onChange={(event) => updateProject(index, "endDate", event.target.value)}
+                    className={cn(inputBaseStyles, dateInputStyles)}
+                  />
+                </StyledInputContainer>
+              </div>
+            </div>
+
+            {/* Description */}
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">
+                Description<RequiredAsterisk />
+              </label>
+              <StyledInputContainer hasError={!!projectErrors?.description}>
                 <textarea
                   value={project.description}
                   onChange={(event) => updateProject(index, "description", event.target.value)}
-                  placeholder="Project description"
+                  placeholder="Describe what the project is about, your role, and its impact..."
                   rows={3}
                   className={cn(textareaBaseStyles, "min-h-28 resize-y")}
                 />
               </StyledInputContainer>
+              <ErrorMessage message={projectErrors?.description} />
             </div>
 
-            <StyledInputContainer>
-              <Input
-                value={project.projectLink}
-                onChange={(event) => updateProject(index, "projectLink", event.target.value)}
-                placeholder="Project link (optional)"
-                containerClassName={inputBaseStyles}
-                className="text-white! py-3"
-              />
-            </StyledInputContainer>
+            {/* Project Link */}
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">Project Link</label>
+              <StyledInputContainer>
+                <Input
+                  value={project.projectLink}
+                  onChange={(event) => updateProject(index, "projectLink", event.target.value)}
+                  placeholder="https://github.com/... (optional)"
+                  containerClassName={inputBaseStyles}
+                  className="text-white! py-3"
+                />
+              </StyledInputContainer>
+            </div>
 
             {imageInputMode === "list" ? (
               <div className="space-y-2">
@@ -346,7 +396,8 @@ export function ProjectsManager({
               </>
             )}
           </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
@@ -181,6 +181,11 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
   const [isSavingProject, setIsSavingProject] = useState(false);
   const [orderedProjectIds, setOrderedProjectIds] = useState<string[]>([]);
   const [page, setPage] = useState(1);
+  const [modalErrors, setModalErrors] = useState<{
+    title?: string;
+    description?: string;
+    startDate?: string;
+  }>({});
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -192,6 +197,11 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
   const handleUpdateProject = (index: number, field: keyof Omit<ProjectFormState, "id">, value: string | File | null) => {
     if (index !== 0) {
       return;
+    }
+
+    // Clear the inline error for the field being edited
+    if (field === "title" || field === "description" || field === "startDate") {
+      setModalErrors((prev) => ({ ...prev, [field]: undefined }));
     }
 
     setEditingProject((prev) => {
@@ -282,12 +292,14 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
   const handleOpenAddProjectModal = () => {
     setIsDeleteConfirmOpen(false);
     setEditingProject(createEmptyProject());
+    setModalErrors({});
     setIsEditModalOpen(true);
   };
 
   const handleOpenEditProjectModal = (project: any) => {
     setIsDeleteConfirmOpen(false);
     setEditingProject(toProjectFormState(project));
+    setModalErrors({});
     setIsEditModalOpen(true);
   };
 
@@ -332,10 +344,18 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
 
     const title = editingProject.title.trim();
     const description = editingProject.description.trim();
-    if (!title || !description || !editingProject.startDate) {
-      toast.error("Please complete title, description, and start date before saving.");
+
+    const nextErrors: { title?: string; description?: string; startDate?: string } = {};
+    if (!title) nextErrors.title = "Project title is required.";
+    if (!description) nextErrors.description = "Project description is required.";
+    if (!editingProject.startDate) nextErrors.startDate = "Start date is required.";
+
+    if (Object.keys(nextErrors).length > 0) {
+      setModalErrors(nextErrors);
       return;
     }
+
+    setModalErrors({});
 
     setIsSavingProject(true);
 
@@ -704,6 +724,7 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
             imageInputMode="list"
             updateProjectImages={handleUpdateProjectImages}
             removeExistingProjectImage={handleRemoveExistingProjectImage}
+            errors={[modalErrors]}
           />
 
           {isImageMutationPending && (


### PR DESCRIPTION
## Summary
This PR improves user experience and validation for project management in the onboarding and profile sections. Previously, the project form lacked inline validation feedback, allowing incomplete submissions without clear guidance on what needed to be corrected.
 
## Changes
- Added inline validation for required fields (`title`, `description`, `startDate`), displaying error messages and highlighting invalid fields in red
- Introduced a new `errors` prop to `ProjectsManager` to pass and display per-project validation errors
- Validation errors are set and cleared as users interact with fields, and reset when opening the modal for add/edit
- Added a visible required asterisk for mandatory fields and improved label clarity for all project input fields

## Additional Information
- No breaking changes to existing props or interfaces
- Validation logic is self-contained within the project modal


<img width="398" height="686" alt="image" src="https://github.com/user-attachments/assets/f6e22bf5-9fc3-4a91-89ae-ef2ec1b7888b" />

Closes #976 