### PR TITLE
feat: add share dropdown in the profile owner sparkmates

### DIFF
--- a/apps/nexus-web/src/app/sparkmates/me/projects/page.tsx
+++ b/apps/nexus-web/src/app/sparkmates/me/projects/page.tsx
@@ -31,6 +31,7 @@ import { SparkmatesRainbowStreak } from "@/features/sparkmates/components/Sparkm
 import { SortableProjectCardItem } from "@/features/sparkmates/components/SparkmatesOwnerView/components/SortableProjectCardItem";
 import { addIcon } from "@/features/sparkmates/components/SparkmatesOwnerView/icons/addIcon";
 import { viewIcon } from "@/features/sparkmates/components/SparkmatesOwnerView/icons/viewIcon";
+import { ShareDropdown } from "@/features/sparkmates/components/SparkmatesOwnerView/components/ShareDropdown";
 import {
   useMemberProjects,
   useMemberProjectsPaginated,
@@ -643,7 +644,7 @@ export default function MyProjectsPage() {
               <Text variant="heading-5" className="text-white">
                 My Portfolio
               </Text>
-              <div className="flex gap-2">
+              <div className="flex items-center gap-2">
                 <Link prefetch={false} href="/sparkmates/me/analytics">
                   <Button
                     variant="colored"
@@ -665,6 +666,7 @@ export default function MyProjectsPage() {
                     Preview
                   </Button>
                 </Link>
+                <ShareDropdown gdgId={gdgId} disabled={!userProfile} />
               </div>
             </div>
 

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
@@ -27,6 +27,7 @@ import {
   normalizeSparkmatesSectionOrder,
   SparkmatesSectionId,
 } from "../../sectionOrder";
+import { ShareDropdown } from "./components/ShareDropdown";
 
 const SECTION_LABELS: Record<SparkmatesSectionId, string> = {
   customButtons: "Custom Buttons",
@@ -542,7 +543,7 @@ export function ProfileOwnerView({
               <Text variant="heading-5" className="text-white">
                 My Portfolio
               </Text>
-              <div className="flex gap-2" role="group" aria-label="Share profile">
+              <div className="flex items-center gap-2" role="group" aria-label="Portfolio actions">
                 <Link prefetch={false} href="/sparkmates/me/analytics">
                   <Button
                     variant="colored"
@@ -553,22 +554,6 @@ export function ProfileOwnerView({
                     Analytics
                   </Button>
                 </Link>
-                {(["facebook", "instagram", "linkedin"] as SharePlatform[]).map((platform) => (
-                  <Button
-                    key={platform}
-                    variant="default"
-                    size="sm"
-                    className={SHARE_BUTTON_CLASSNAMES[platform]}
-                    title={`Share on ${SHARE_PLATFORM_LABELS[platform]}`}
-                    aria-label={`Share on ${SHARE_PLATFORM_LABELS[platform]}`}
-                    onClick={() => {
-                      void handleShare(platform);
-                    }}
-                    disabled={isSharing}
-                  >
-                    {SHARE_PLATFORM_LABELS[platform]}
-                  </Button>
-                ))}
                 <Button
                   variant="default"
                   size="sm"
@@ -582,6 +567,11 @@ export function ProfileOwnerView({
                 >
                   Preview
                 </Button>
+                <ShareDropdown
+                  gdgId={effectiveGdgId}
+                  disabled={!userprofile || isSharing}
+                  onShare={(platform) => { void handleShare(platform); }}
+                />
               </div>
             </div>
 

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/ShareDropdown.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/ShareDropdown.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import React, { useState } from "react";
+import { toast } from "react-toastify";
+import {
+  Dropdown,
+  DropdownTrigger,
+  DropdownContent,
+  DropdownItem,
+  DropdownSeparator,
+  Button,
+} from "@packages/spark-ui";
+import { ChevronDown, Facebook, Instagram, Linkedin, Link } from "lucide-react";
+
+type SharePlatform = "facebook" | "instagram" | "linkedin";
+
+interface ShareDropdownProps {
+  gdgId: string;
+  disabled?: boolean;
+  /** If provided, clicking FB/IG/LI will call this instead of opening a window directly. */
+  onShare?: (platform: SharePlatform) => void;
+}
+
+const getPortfolioUrl = (gdgId: string): string => {
+  const base =
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    (typeof window !== "undefined" ? window.location.origin : "https://gdgpup.org");
+  return `${base}/sparkmates/${gdgId}`;
+};
+
+export function ShareDropdown({ gdgId, disabled, onShare }: ShareDropdownProps) {
+  const portfolioUrl = getPortfolioUrl(gdgId);
+
+  const handlePlatform = (platform: SharePlatform) => {
+    if (onShare) {
+      onShare(platform);
+      return;
+    }
+
+    // Fallback: direct open (used on pages without the share modal)
+    if (platform === "facebook") {
+      window.open(
+        `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(portfolioUrl)}`,
+        "_blank",
+        "noopener,noreferrer,width=620,height=720",
+      );
+    } else if (platform === "instagram") {
+      window.open("https://www.instagram.com/", "_blank", "noopener,noreferrer");
+    } else {
+      window.open(
+        `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(portfolioUrl)}`,
+        "_blank",
+        "noopener,noreferrer,width=620,height=720",
+      );
+    }
+  };
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(portfolioUrl);
+      toast.success("Portfolio link copied to clipboard!", {
+        position: "bottom-right",
+        autoClose: 2500,
+      });
+    } catch {
+      toast.error("Failed to copy link. Please copy it manually.", {
+        position: "bottom-right",
+      });
+    }
+  };
+
+  return (
+    <Dropdown>
+      <DropdownTrigger asChild>
+        <Button
+          variant="default"
+          size="sm"
+          className="px-3 py-1 text-white flex items-center gap-1.5"
+          disabled={disabled}
+          aria-label="Share portfolio"
+        >
+          Share
+          <ChevronDown size={13} className="opacity-70" />
+        </Button>
+      </DropdownTrigger>
+
+      <DropdownContent position="bottom-end" size="md" animation>
+        {/* Facebook */}
+        <DropdownItem
+          icon={<Facebook size={15} className="text-[#1877F2]" />}
+          onClick={() => handlePlatform("facebook")}
+        >
+          Facebook
+        </DropdownItem>
+
+        {/* Instagram */}
+        <DropdownItem
+          icon={
+            <Instagram size={15} className="text-[#E1306C]" />
+          }
+          onClick={() => handlePlatform("instagram")}
+        >
+          Instagram
+        </DropdownItem>
+
+        {/* LinkedIn */}
+        <DropdownItem
+          icon={<Linkedin size={15} className="text-[#0A66C2]" />}
+          onClick={() => handlePlatform("linkedin")}
+        >
+          LinkedIn
+        </DropdownItem>
+
+        <DropdownSeparator />
+
+        {/* Copy Link */}
+        <DropdownItem
+          icon={<Link size={15} className="text-zinc-400" />}
+          onClick={handleCopyLink}
+        >
+          Copy Link
+        </DropdownItem>
+      </DropdownContent>
+    </Dropdown>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new reusable `ShareDropdown` component for sharing Sparkmates portfolios and refactors existing share button implementations to use this component. The main goals are to streamline the sharing UI, improve code maintainability, and enhance the user experience with a consistent dropdown menu for sharing actions.

**Key changes:**

### Feature Addition

* Added a new `ShareDropdown` component in `ShareDropdown.tsx`, providing a dropdown menu for sharing the portfolio via Facebook, Instagram, LinkedIn, or by copying a link. The component handles both direct sharing and custom share logic via an optional callback.

### Refactoring & UI Consistency

* Replaced individual share buttons in `ProfileOwnerView.tsx` with the new `ShareDropdown` component, simplifying the code and ensuring a consistent UI for sharing actions. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL545-R546) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL556-L571) [[3]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR570-R574)
* Updated the "My Portfolio" actions section in both `ProfileOwnerView.tsx` and `page.tsx` to use `flex items-center gap-2` for better alignment and spacing of action buttons, including the new dropdown. [[1]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL545-R546) [[2]](diffhunk://#diff-960f1fcd698b8a3c1526d35d184e313bbfecd3f2a1127e501ceeb2db08e0dacaL646-R647) [[3]](diffhunk://#diff-960f1fcd698b8a3c1526d35d184e313bbfecd3f2a1127e501ceeb2db08e0dacaR669)

### Imports & Integration

* Imported the new `ShareDropdown` component into both the Sparkmates projects page (`page.tsx`) and the owner profile view (`ProfileOwnerView.tsx`) to enable sharing functionality in both locations. [[1]](diffhunk://#diff-960f1fcd698b8a3c1526d35d184e313bbfecd3f2a1127e501ceeb2db08e0dacaR34) [[2]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fR30)

<img width="1527" height="930" alt="image" src="https://github.com/user-attachments/assets/cc163e3d-9574-4fd3-8fdf-103e8d96a210" />
