### PR TITLE
feat: resolve the modal issues in mobile

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/sections/NameAndProfileSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/NameAndProfileSection.tsx
@@ -14,8 +14,8 @@ import {
   serializeCustomButtonLinks,
 } from "../../utils/customButtonFavorites";
 
-const StyledInputContainer = ({ children }: { children: React.ReactNode }) => (
-  <div className="relative group w-full rounded-[8px] p-[1px] focus-within:p-[2px] bg-[#737373] hover:bg-gradient-to-r focus-within:bg-gradient-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_0_10px_rgba(251,44,54,0.35),0_0_20px_rgba(240,177,0,0.3),0_0_32px_rgba(43,127,255,0.4)] transition-all duration-300 ease-in-out">
+const StyledInputContainer = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={cn("relative group w-full rounded-[8px] p-[1px] focus-within:p-[2px] bg-[#737373] hover:bg-gradient-to-r focus-within:bg-gradient-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_0_10px_rgba(251,44,54,0.35),0_0_20px_rgba(240,177,0,0.3),0_0_32px_rgba(43,127,255,0.4)] transition-all duration-300 ease-in-out", className)}>
     {children}
   </div>
 );
@@ -331,7 +331,7 @@ export const NameAndProfileSection = ({
         size="sm"
         className="bg-transparent border-none p-0 !shadow-none isolate max-w-[95vw] sm:max-w-md"
       >
-        <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-6 py-8 sm:px-8 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
+        <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-4 py-8 sm:px-8 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <Text variant="heading-6" weight="bold" gradient="white-yellow">Edit Profile</Text>
@@ -390,8 +390,8 @@ export const NameAndProfileSection = ({
             </div>
 
             <div className="flex justify-end gap-3 pt-6 border-t border-white/10">
-              <Button variant="ghost" type="button" className="h-auto py-2 sm:py-2 px-5" onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
-              <Button variant="colored" subVariant="blue" type="submit" className="h-auto py-2 sm:py-2 px-5" disabled={isPending}>
+              <Button variant="ghost" type="button" className="h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
+              <Button variant="colored" subVariant="blue" type="submit" className="h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" disabled={isPending}>
                 {isPending ? "Saving..." : "Save Changes"}
               </Button>
             </div>
@@ -409,7 +409,7 @@ export const NameAndProfileSection = ({
           size="sm"
           className="bg-transparent border-none p-0 !shadow-none isolate max-w-[95vw] sm:max-w-sm"
         >
-          <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-6 py-8 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
+          <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-4 py-8 sm:px-6 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
             <div className="space-y-4">
               <div>
                 <Text variant="heading-6" weight="bold" gradient="white-yellow">Manage Links</Text>
@@ -421,17 +421,17 @@ export const NameAndProfileSection = ({
               <div className="space-y-1.5 flex flex-col">
                 <Text variant="body-sm" className="text-zinc-300 font-medium">Link URL</Text>
                 <div className="flex gap-2">
-                  <StyledInputContainer>
+                  <StyledInputContainer className="flex-1 min-w-0">
                     <Input
                       value={newLink}
                       onChange={(e) => setNewLink(e.target.value)}
                       onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), handleAddLink())}
                       placeholder="https://your-link.com"
                       containerClassName={inputBaseStyles}
-                      className="text-white! py-2 sm:py-2.5"
+                      className="text-white! py-2 sm:py-2.5 min-w-0"
                     />
                   </StyledInputContainer>
-                  <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-4" onClick={handleAddLink}>Add</Button>
+                  <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-3 sm:px-4 shrink-0 !text-sm !font-medium whitespace-nowrap" onClick={handleAddLink}>Add</Button>
                 </div>
               </div>
 
@@ -441,15 +441,15 @@ export const NameAndProfileSection = ({
                   {links.map((link, index) => (
                     <div key={index} className="flex items-center justify-between gap-2 p-3 rounded-xl border border-white/5 bg-white/5 hover:border-white/10 transition-colors">
                       <Text variant="body-sm" className="truncate flex-1 text-zinc-200">{link}</Text>
-                      <Button variant="ghost" size="sm" onClick={() => handleRemoveLink(index)} className="text-red-400 hover:text-red-300 hover:bg-red-400/10">Remove</Button>
+                      <Button variant="ghost" size="sm" onClick={() => handleRemoveLink(index)} className="text-red-400 hover:text-red-300 hover:bg-red-400/10 !text-sm !font-medium">Remove</Button>
                     </div>
                   ))}
                 </div>
               )}
 
               <div className="flex justify-end gap-3 pt-6 border-t border-zinc-800/80">
-                <Button variant="ghost" className="h-auto py-2 sm:py-2 px-5" onClick={() => setIsLinksModalOpen(false)}>Cancel</Button>
-                <Button variant="colored" subVariant="blue" className="h-auto py-2 sm:py-2 px-5" onClick={handleSaveLinks} disabled={isPending}>
+                <Button variant="ghost" className="h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" onClick={() => setIsLinksModalOpen(false)}>Cancel</Button>
+                <Button variant="colored" subVariant="blue" className="h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" onClick={handleSaveLinks} disabled={isPending}>
                   {isPending ? "Saving..." : "Save Links"}
                 </Button>
               </div>

--- a/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
@@ -702,7 +702,7 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
         size="md"
         className="bg-transparent border-none p-0 shadow-none! isolate"
       >
-        <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-6 py-8 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
+        <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-4 sm:px-6 py-8 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
         <div className="space-y-6">
           <div>
             <Text variant="heading-6" weight="bold" gradient="white-yellow">
@@ -734,20 +734,20 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
             </div>
           )}
           
-          <div className="flex justify-end gap-3 pt-6 border-t border-zinc-800/80">
-            <Button variant="ghost" onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
+          <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-3 pt-6 border-t border-zinc-800/80">
+            <Button variant="ghost" className="w-full sm:w-auto h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
             {editingProject.id && (
               <Button
                 variant="colored"
                 subVariant="red"
-                className="bg-red-600 hover:bg-red-700 text-white"
+                className="w-full sm:w-auto bg-red-600 hover:bg-red-700 text-white h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap"
                 onClick={handleDeleteCurrentProject}
                 disabled={isSaving}
               >
                 Delete Project
               </Button>
             )}
-            <Button variant="colored" subVariant="blue" onClick={handleSave} disabled={isSaving}>
+            <Button variant="colored" subVariant="blue" className="w-full sm:w-auto h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" onClick={handleSave} disabled={isSaving}>
               {isSaving ? (
                 <span className="inline-flex items-center gap-2">
                   <GdgLoader size="xs" />

--- a/apps/nexus-web/src/features/sparkmates/components/sections/SkillsAndLinksSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/SkillsAndLinksSection.tsx
@@ -124,8 +124,8 @@ function CategoryCard({
   );
 }
 
-const StyledInputContainer = ({ children }: { children: React.ReactNode }) => (
-  <div className="relative group w-full rounded-[8px] p-[1px] focus-within:p-[2px] bg-[#737373] hover:bg-gradient-to-r focus-within:bg-gradient-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_0_10px_rgba(251,44,54,0.35),0_0_20px_rgba(240,177,0,0.3),0_0_32px_rgba(43,127,255,0.4)] transition-all duration-300 ease-in-out">
+const StyledInputContainer = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={cn("relative group w-full rounded-[8px] p-[1px] focus-within:p-[2px] bg-[#737373] hover:bg-gradient-to-r focus-within:bg-gradient-to-r hover:from-[#FB2C36] hover:via-[#F0B100] hover:to-[#2B7FFF] focus-within:from-[#FB2C36] focus-within:via-[#F0B100] focus-within:to-[#2B7FFF] focus-within:shadow-[0_0_10px_rgba(251,44,54,0.35),0_0_20px_rgba(240,177,0,0.3),0_0_32px_rgba(43,127,255,0.4)] transition-all duration-300 ease-in-out", className)}>
     {children}
   </div>
 );
@@ -236,7 +236,7 @@ export function SkillsAndLinksSection({
 
       {!readOnly && (
         <Modal open={isEditModalOpen} onOpenChange={setIsEditModalOpen} scrollBehavior="inside" size="sm" className="bg-transparent border-none p-0 !shadow-none isolate max-w-[95vw] sm:max-w-md">
-        <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-6 py-8 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
+        <div className="relative overflow-hidden w-full rounded-3xl bg-[#010B1D]/80 backdrop-blur-2xl px-4 sm:px-6 py-8 border border-white/10 shadow-[0_0_80px_rgba(0,0,0,0.6),inset_0px_4px_16px_rgba(255,255,255,0.05)]">
         <div className="space-y-6">
           <div>
             <Text variant="heading-6" weight="bold" gradient="white-yellow">Manage Skills and Interests</Text>
@@ -248,17 +248,17 @@ export function SkillsAndLinksSection({
           <div className="space-y-2 flex flex-col">
             <Text variant="body-sm" className="text-zinc-300 font-medium">Technical Skills</Text>
             <div className="flex gap-2">
-              <StyledInputContainer>
+              <StyledInputContainer className="flex-1 min-w-0">
                 <Input 
                   value={newSkill} 
                   onChange={(e) => setNewSkill(e.target.value)} 
                   onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddTag(skills, setSkills, newSkill, setNewSkill))}
                   placeholder="e.g. React"
                   containerClassName={inputBaseStyles}
-                  className="text-white! py-2 sm:py-2.5"
+                  className="text-white! py-2 sm:py-2.5 min-w-0"
                 />
               </StyledInputContainer>
-              <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-4" onClick={() => handleAddTag(skills, setSkills, newSkill, setNewSkill)}>Add</Button>
+              <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-3 sm:px-4 shrink-0 !text-sm !font-medium whitespace-nowrap" onClick={() => handleAddTag(skills, setSkills, newSkill, setNewSkill)}>Add</Button>
             </div>
             <div className="flex flex-wrap gap-2">
               {skills.map((tag, i) => (
@@ -273,17 +273,17 @@ export function SkillsAndLinksSection({
           <div className="space-y-2 flex flex-col">
             <Text variant="body-sm" className="text-zinc-300 font-medium">Interests</Text>
             <div className="flex gap-2">
-              <StyledInputContainer>
+              <StyledInputContainer className="flex-1 min-w-0">
                 <Input 
                   value={newInterest} 
                   onChange={(e) => setNewInterest(e.target.value)} 
                   onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddTag(interests, setInterests, newInterest, setNewInterest))}
                   placeholder="e.g. Public Speaking"
                   containerClassName={inputBaseStyles}
-                  className="text-white! py-2 sm:py-2.5"
+                  className="text-white! py-2 sm:py-2.5 min-w-0"
                 />
               </StyledInputContainer>
-              <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-4" onClick={() => handleAddTag(interests, setInterests, newInterest, setNewInterest)}>Add</Button>
+              <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-3 sm:px-4 shrink-0 !text-sm !font-medium whitespace-nowrap" onClick={() => handleAddTag(interests, setInterests, newInterest, setNewInterest)}>Add</Button>
             </div>
             <div className="flex flex-wrap gap-2">
               {interests.map((tag, i) => (
@@ -298,17 +298,17 @@ export function SkillsAndLinksSection({
           <div className="space-y-2 flex flex-col">
             <Text variant="body-sm" className="text-zinc-300 font-medium">Tech Stack / Tools</Text>
             <div className="flex gap-2">
-              <StyledInputContainer>
+              <StyledInputContainer className="flex-1 min-w-0">
                 <Input 
                   value={newTool} 
                   onChange={(e) => setNewTool(e.target.value)} 
                   onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddTag(tools, setTools, newTool, setNewTool))}
                   placeholder="e.g. VS Code"
                   containerClassName={inputBaseStyles}
-                  className="text-white! py-2 sm:py-2.5"
+                  className="text-white! py-2 sm:py-2.5 min-w-0"
                 />
               </StyledInputContainer>
-              <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-4" onClick={() => handleAddTag(tools, setTools, newTool, setNewTool)}>Add</Button>
+              <Button variant="colored" subVariant="dark-blue" className="h-auto py-2 sm:py-2.5 px-3 sm:px-4 shrink-0 !text-sm !font-medium whitespace-nowrap" onClick={() => handleAddTag(tools, setTools, newTool, setNewTool)}>Add</Button>
             </div>
             <div className="flex flex-wrap gap-2">
               {tools.map((tag, i) => (
@@ -321,8 +321,8 @@ export function SkillsAndLinksSection({
           </div>
 
           <div className="flex justify-end gap-3 pt-6 border-t border-zinc-800/80">
-            <Button variant="ghost" className="h-auto py-2 sm:py-2.5 px-6" onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
-            <Button variant="colored" subVariant="blue" className="h-auto py-2 sm:py-2.5 px-6" onClick={handleSave} disabled={isPending}>
+            <Button variant="ghost" className="h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
+            <Button variant="colored" subVariant="blue" className="h-auto py-2 sm:py-2 px-4 sm:px-5 !text-sm !font-medium whitespace-nowrap" onClick={handleSave} disabled={isPending}>
               {isPending ? "Saving..." : "Save Changes"}
             </Button>
           </div>


### PR DESCRIPTION
This pull request focuses on improving the consistency, responsiveness, and usability of modal dialogs and form controls in the Sparkmates profile sections. The main changes involve standardizing modal paddings, button sizes, and input containers across the `NameAndProfileSection`, `SkillsAndLinksSection`, and `ProjectsSection` components. These updates ensure a more polished and accessible user interface, especially on different screen sizes.

**Modal and Form Layout Consistency:**

* Updated modal dialog paddings to use `px-4 sm:px-6` or `px-4 sm:px-8` instead of fixed paddings, making layouts more responsive and visually consistent across profile sections. [[1]](diffhunk://#diff-e6a4639e99524234d003e155c4bbcf428a26e92ae767ff87b0dc7ba23c0f4796L334-R334) [[2]](diffhunk://#diff-e6a4639e99524234d003e155c4bbcf428a26e92ae767ff87b0dc7ba23c0f4796L412-R412) [[3]](diffhunk://#diff-70ada52a56c11beb6ac5c6ff5c40c4ce7d847301e97219c4df2b29c21986e2adL705-R705) [[4]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L239-R239)

**Button Styling and Accessibility:**

* Standardized button sizes, paddings, and font styles in all modals and forms to use consistent `px-4 sm:px-5`, `!text-sm !font-medium`, and `whitespace-nowrap` classes, improving touch targets and text readability. This applies to "Cancel", "Save", "Add", and "Remove" buttons. [[1]](diffhunk://#diff-e6a4639e99524234d003e155c4bbcf428a26e92ae767ff87b0dc7ba23c0f4796L393-R394) [[2]](diffhunk://#diff-e6a4639e99524234d003e155c4bbcf428a26e92ae767ff87b0dc7ba23c0f4796L424-R434) [[3]](diffhunk://#diff-e6a4639e99524234d003e155c4bbcf428a26e92ae767ff87b0dc7ba23c0f4796L444-R452) [[4]](diffhunk://#diff-70ada52a56c11beb6ac5c6ff5c40c4ce7d847301e97219c4df2b29c21986e2adL737-R750) [[5]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L251-R261) [[6]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L276-R286) [[7]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L301-R311) [[8]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L324-R325)

**Input Container Flexibility:**

* Refactored the `StyledInputContainer` component to accept an optional `className` prop, allowing more flexible layout control (e.g., `flex-1 min-w-0`) for better alignment and responsiveness of input fields. [[1]](diffhunk://#diff-e6a4639e99524234d003e155c4bbcf428a26e92ae767ff87b0dc7ba23c0f4796L17-R18) [[2]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L127-R128)

**Form Field Responsiveness:**

* Updated input fields and their containers to support flexible layouts and prevent overflow, ensuring they scale properly on smaller screens and within flex layouts. [[1]](diffhunk://#diff-e6a4639e99524234d003e155c4bbcf428a26e92ae767ff87b0dc7ba23c0f4796L424-R434) [[2]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L251-R261) [[3]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L276-R286) [[4]](diffhunk://#diff-9dcba0f6d28a8873aff47bb178bd725886bbdc8496a5f7d6c4f1950ce5b06974L301-R311)

**Section-Specific UI Improvements:**

* Adjusted the layout of the project edit modal's action buttons to stack vertically on mobile and align horizontally on larger screens for improved usability.

These changes collectively enhance the user experience by making the UI more consistent, accessible, and responsive across all profile editing dialogs.

<img width="447" height="820" alt="image" src="https://github.com/user-attachments/assets/8ac07963-43b5-4f35-96e3-7bf1bd0e1a46" />
