### PR TITLE
fix: navbar active state for /about route and update onboarding place…

### DIFF
--- a/apps/nexus-web/src/components/shared/Navbar.tsx
+++ b/apps/nexus-web/src/components/shared/Navbar.tsx
@@ -348,7 +348,9 @@ export const Navbar: React.FC<NavbarProps> = ({
                   >
                     <div className={dropdownInnerClasses}>
                       {dropdownLinks.about.map((link) => {
-                        const isActive = pathname === link.href || pathname.startsWith(link.href + "/");
+                        const isActive = link.href === "/about"
+                          ? pathname === link.href
+                          : pathname === link.href || pathname.startsWith(link.href + "/");
                         return (
                           <Link prefetch={false}
                             key={link.href}
@@ -580,7 +582,9 @@ export const Navbar: React.FC<NavbarProps> = ({
                     >
                       <div className="bg-white/5 py-2">
                         {dropdownLinks.about.map((link) => {
-                          const isActive = pathname === link.href || pathname.startsWith(link.href + "/");
+                          const isActive = link.href === "/about"
+                            ? pathname === link.href
+                            : pathname === link.href || pathname.startsWith(link.href + "/");
                           return (
                             <Link prefetch={false}
                               key={link.href}

--- a/apps/nexus-web/src/features/onboarding/components/BasicInfoFields.tsx
+++ b/apps/nexus-web/src/features/onboarding/components/BasicInfoFields.tsx
@@ -41,7 +41,7 @@ export function BasicInfoFields({ form, updateField }: BasicInfoFieldsProps) {
         <Input
           value={form.department}
           onChange={(event) => updateField("department", event.target.value)}
-          placeholder="e.g. College of Computer and Information Sciences"
+          placeholder="e.g. Marketing Department"
           containerClassName="bg-zinc-900/50! border-zinc-700/80! hover:border-zinc-600! focus-within:border-blue-500/50!"
           className="text-white! py-3"
         />


### PR DESCRIPTION

- Fix active nav highlighting wrong item on History page by using exact
  match for /about route instead of partial route matching (#1078)
- Update department field placeholder from academic example to
  organization-relevant example (#1077)

Fixes #1078
Fixes #1077
