### PR TITLE
chore: add cancel button for session expired modal

### DIFF
--- a/apps/nexus-admin-web/src/features/authentication/components/SessionExpiredOnLoadModal.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/components/SessionExpiredOnLoadModal.tsx
@@ -37,12 +37,20 @@ export const SessionExpiredOnLoadModal = () => {
           </p>
         </div>
 
-        <button
-          onClick={handleLoginAgain}
-          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2.5 rounded-lg shadow-sm transition-all"
-        >
-          Log In Again
-        </button>
+        <div className="flex flex-col gap-3 w-full">
+          <button
+            onClick={handleLoginAgain}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2.5 rounded-lg shadow-sm transition-all"
+          >
+            Log In Again
+          </button>
+          <button
+            onClick={clearSessionExpiredOnLoad}
+            className="w-full text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 font-medium py-2 transition-all"
+          >
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/nexus-web/src/features/authentication/components/SessionExpiredOnLoadModal.tsx
+++ b/apps/nexus-web/src/features/authentication/components/SessionExpiredOnLoadModal.tsx
@@ -34,13 +34,22 @@ export const SessionExpiredOnLoadModal = () => {
           </Text>
         </div>
 
-        <Button
-          variant="default"
-          onClick={handleLoginAgain}
-          className="w-full !bg-gradient-to-t !from-[#2b7fff] !to-[#162456] !border-none !shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25),inset_0px_2px_0px_0px_rgba(255,255,255,0.4)]"
-        >
-          Log In Again
-        </Button>
+        <Stack gap="sm">
+          <Button
+            variant="default"
+            onClick={handleLoginAgain}
+            className="w-full !bg-gradient-to-t !from-[#2b7fff] !to-[#162456] !border-none !shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25),inset_0px_2px_0px_0px_rgba(255,255,255,0.4)]"
+          >
+            Log In Again
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={clearSessionExpiredOnLoad}
+            className="w-full text-white/70 hover:text-white"
+          >
+            Cancel
+          </Button>
+        </Stack>
       </Stack>
     </Modal>
   );


### PR DESCRIPTION
This pull request adds a "Cancel" button to the session expiration modal in both the `nexus-admin-web` and `nexus-web` applications. This allows users to dismiss the modal without logging in again, improving the user experience when a session expires.

**Session Expiration Modal Improvements:**

* Added a "Cancel" button to the session expired modal in `SessionExpiredOnLoadModal.tsx` for `nexus-admin-web`, allowing users to dismiss the modal without logging in again.
* Added a "Cancel" button to the session expired modal in `SessionExpiredOnLoadModal.tsx` for `nexus-web`, providing the same dismiss functionality for consistency across applications.