### PR TITLE
feat(nexus-web): improve profile UI for public sparkmates

### DIFF
--- a/apps/nexus-web/src/features/sparkmates/components/sections/CustomButtonsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/CustomButtonsSection.tsx
@@ -296,9 +296,11 @@ export const CustomButtonsSection = ({ profile, readOnly }: { profile: UserProfi
             </Button>
           )}
         </div>
-        <Text variant="body-sm" className="text-[#C1C7CD]">
-          Add a custom button that appears on your profile.
-        </Text>
+        {!readOnly && (
+          <Text variant="body-sm" className="text-[#C1C7CD]">
+            Add a custom button that appears on your profile.
+          </Text>
+        )}
         <div className="space-y-2.5">
           {customLinks.map((item, index) => (
             <div

--- a/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
@@ -586,12 +586,13 @@ export const ProjectsSection = ({ profile, readOnly }: { profile: UserProfile; r
           </Button>
         </Link>
       </div>
-      <Text variant="body-sm" className="text-[#C1C7CD]">
-        Feature your best works to highlight your skills.
-      </Text>
-      
-      <div className="space-y-3.5">
-        {projectsQuery.isLoading ? (
+      {!readOnly && (
+        <Text variant="body-sm" className="text-[#C1C7CD]">
+          Feature your best works to highlight your skills.
+        </Text>
+      )}
+
+      <div className="space-y-3.5">        {projectsQuery.isLoading ? (
           <div className="inline-flex items-center gap-2 text-zinc-300">
             <GdgLoader size="xs" />
             <Text variant="body-sm" className="text-zinc-300">Loading projects...</Text>

--- a/apps/nexus-web/src/features/sparkmates/components/sections/SkillsAndLinksSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/SkillsAndLinksSection.tsx
@@ -198,9 +198,11 @@ export function SkillsAndLinksSection({
         )}
       </div>
 
-      <Text variant="body-sm" className="text-[#C1C7CD]">
-        Add your skills or what you are currently learning.
-      </Text>
+      {!readOnly && (
+        <Text variant="body-sm" className="text-[#C1C7CD]">
+          Add your skills or what you are currently learning.
+        </Text>
+      )}
 
       <div className="space-y-3">
         <CategoryCard


### PR DESCRIPTION
This pull request improves the user experience in the Sparkmates profile sections by ensuring that instructional helper text is only shown when the profile is in edit mode. This prevents unnecessary prompts from appearing to users who are simply viewing profiles, resulting in a cleaner and less distracting interface.

Conditional display of helper text in edit mode:

* In `CustomButtonsSection.tsx`, the helper text for adding a custom button now only appears when `readOnly` is false, so viewers won't see editing instructions.
* In `ProjectsSection.tsx`, the instructional text about featuring projects is now conditionally rendered based on the `readOnly` flag.
* In `SkillsAndLinksSection.tsx`, the prompt to add skills or learning topics is also shown only in edit mode, respecting the `readOnly` state.