### PR TITLE
feat: nexus-branded toast system with custom animations and type-specific accents

### DIFF
--- a/apps/nexus-web/src/app/activate/[cardUid]/page.tsx
+++ b/apps/nexus-web/src/app/activate/[cardUid]/page.tsx
@@ -14,7 +14,7 @@
 import { configs } from "@/configs/servers.config";
 import { useParams, useRouter } from "next/navigation";
 import React, { useState } from "react";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { ASSETS } from "@/lib/constants/assets";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";
 import { LoadingScreen } from "@/components/shared";

--- a/apps/nexus-web/src/app/globals.css
+++ b/apps/nexus-web/src/app/globals.css
@@ -444,4 +444,240 @@ html.lenis {
   background: rgba(15, 14, 14, 0.9);
 }
 
+/* ── React-Toastify — Nexus Brand Overrides ────────────────────────────── */
+
+/* Custom slide-up-fade entry/exit animation */
+@keyframes nexusToastIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes nexusToastOut {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+}
+
+/* Container shell */
+.Toastify__toast {
+  background: rgba(10, 10, 12, 0.82) !important;
+  backdrop-filter: blur(24px) saturate(160%) !important;
+  -webkit-backdrop-filter: blur(24px) saturate(160%) !important;
+  border: 1px solid rgba(255, 255, 255, 0.09) !important;
+  border-radius: 16px !important;
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.4),
+    0 12px 32px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset !important;
+  font-family: "Google Sans", system-ui, -apple-system, sans-serif !important;
+  font-size: 0.875rem !important;
+  color: rgba(255, 255, 255, 0.90) !important;
+  padding: 0 !important;
+  min-height: unset !important;
+  overflow: hidden !important;
+  cursor: default !important;
+  /* No animation here — let toastify control enter/exit via its own classes */
+  transition: transform 180ms ease, box-shadow 180ms ease !important;
+}
+
+/* Hook into toastify's slide transition classes for bottom-right */
+.Toastify__slide-enter--bottom-right,
+.Toastify__slide-enter--top-right {
+  animation: nexusToastIn 280ms cubic-bezier(0.22, 1, 0.36, 1) both !important;
+}
+
+.Toastify__slide-exit--bottom-right,
+.Toastify__slide-exit--top-right {
+  animation: nexusToastOut 220ms ease-in forwards !important;
+}
+
+.Toastify__toast--close-on-click:active {
+  transform: scale(0.98) !important;
+}
+
+/* Hover lift effect */
+.Toastify__toast:hover {
+  transform: translateY(-2px) !important;
+  box-shadow:
+    0 6px 12px rgba(0, 0, 0, 0.45),
+    0 16px 40px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.06) inset !important;
+}
+
+/* Type-specific hover glow (uses --nexus-accent set inline) */
+.Toastify__toast--success:hover {
+  box-shadow:
+    0 6px 12px rgba(0, 0, 0, 0.45),
+    0 16px 40px rgba(0, 0, 0, 0.6),
+    0 0 20px rgba(52, 168, 83, 0.12) !important;
+}
+
+.Toastify__toast--error:hover {
+  box-shadow:
+    0 6px 12px rgba(0, 0, 0, 0.45),
+    0 16px 40px rgba(0, 0, 0, 0.6),
+    0 0 20px rgba(234, 67, 53, 0.12) !important;
+}
+
+.Toastify__toast--warning:hover {
+  box-shadow:
+    0 6px 12px rgba(0, 0, 0, 0.45),
+    0 16px 40px rgba(0, 0, 0, 0.6),
+    0 0 20px rgba(249, 171, 0, 0.12) !important;
+}
+
+.Toastify__toast--info:hover {
+  box-shadow:
+    0 6px 12px rgba(0, 0, 0, 0.45),
+    0 16px 40px rgba(0, 0, 0, 0.6),
+    0 0 20px rgba(43, 127, 255, 0.12) !important;
+}
+
+/* Hide default body wrapper padding */
+.Toastify__toast-body {
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* Progress bar — Nexus brand gradient */
+.Toastify__progress-bar {
+  background: linear-gradient(90deg, #2b7fff 0%, #a855f7 55%, #ec4899 100%) !important;
+  opacity: 1 !important;
+  height: 2px !important;
+  border-radius: 0 !important;
+}
+
+.Toastify__progress-bar--bg {
+  background: rgba(255, 255, 255, 0.04) !important;
+}
+
+/* Type-specific progress bar colours */
+.Toastify__toast--success .Toastify__progress-bar {
+  background: linear-gradient(90deg, #34a853, #2b7fff) !important;
+}
+
+.Toastify__toast--error .Toastify__progress-bar {
+  background: linear-gradient(90deg, #ea4335, #f9ab00) !important;
+}
+
+.Toastify__toast--warning .Toastify__progress-bar {
+  background: linear-gradient(90deg, #f9ab00, #ea4335) !important;
+}
+
+.Toastify__toast--info .Toastify__progress-bar {
+  background: linear-gradient(90deg, #2b7fff, #a855f7) !important;
+}
+
+/* ── NexusToast inner layout ─────────────────────────────────────────────── */
+
+/* Force the body wrapper to be a plain block so our inner flex takes over */
+.Toastify__toast-body {
+  display: block !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  flex: 1 !important;
+}
+
+.nexus-toast-inner {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  gap: 12px;
+  padding: 13px 14px 13px 0;
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Left accent bar */
+.nexus-toast-accent-bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  border-radius: 16px 0 0 16px;
+  background: var(--nexus-accent, #2b7fff);
+  box-shadow: 0 0 8px var(--nexus-accent, #2b7fff);
+  flex-shrink: 0;
+}
+
+/* Icon pill */
+.nexus-toast-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+/* Text block */
+.nexus-toast-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.nexus-toast-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--nexus-accent, #2b7fff);
+  margin: 0;
+  line-height: 1;
+}
+
+.nexus-toast-message {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.85);
+  margin: 0;
+  line-height: 1.45;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+/* Close button */
+.nexus-toast-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.35);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 150ms ease, color 150ms ease;
+  padding: 0;
+  margin-right: 4px;
+}
+
+.nexus-toast-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.80);
+}
+
+
+
 

--- a/apps/nexus-web/src/app/nfc-cards/[cardId]/activate/page.tsx
+++ b/apps/nexus-web/src/app/nfc-cards/[cardId]/activate/page.tsx
@@ -14,7 +14,7 @@
 import { configs } from "@/configs/servers.config";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import React, { useState } from "react";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { ASSETS } from "@/lib/constants/assets";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";
 import { useCardActivation } from "@/features/nfc-cards/hooks/useActivateCardMutation";

--- a/apps/nexus-web/src/app/sparkmates/me/projects/page.tsx
+++ b/apps/nexus-web/src/app/sparkmates/me/projects/page.tsx
@@ -41,7 +41,7 @@ import { ProjectsManager } from "@/features/onboarding/components/ProjectsManage
 import { ProjectFormState } from "@/features/onboarding/types";
 import { ProjectDeleteConfirmDialog } from "@/features/sparkmates/components/ProjectDeleteConfirmDialog";
 import { getMemberProjectById } from "@/features/sparkmates/api/memberProjects";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 
 const PROJECTS_PER_PAGE = 4;
 const MAX_PROJECT_IMAGES = 4;

--- a/apps/nexus-web/src/components/shared/NexusToast.tsx
+++ b/apps/nexus-web/src/components/shared/NexusToast.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { toast, type ToastOptions } from "react-toastify";
+import {
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Info,
+  X,
+} from "lucide-react";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type ToastType = "success" | "error" | "warning" | "info";
+
+interface NexusToastContentProps {
+  message: string;
+  type: ToastType;
+  closeToast?: () => void;
+}
+
+// ── Config per type ───────────────────────────────────────────────────────────
+
+const CONFIG: Record<
+  ToastType,
+  {
+    icon: React.ReactNode;
+    accent: string;      // left-border + glow colour (CSS colour)
+    iconBg: string;      // icon pill background
+    label: string;
+  }
+> = {
+  success: {
+    icon: <CheckCircle2 size={18} strokeWidth={2.2} />,
+    accent: "#34a853",
+    iconBg: "rgba(52, 168, 83, 0.15)",
+    label: "Success",
+  },
+  error: {
+    icon: <XCircle size={18} strokeWidth={2.2} />,
+    accent: "#ea4335",
+    iconBg: "rgba(234, 67, 53, 0.15)",
+    label: "Error",
+  },
+  warning: {
+    icon: <AlertTriangle size={18} strokeWidth={2.2} />,
+    accent: "#f9ab00",
+    iconBg: "rgba(249, 171, 0, 0.15)",
+    label: "Warning",
+  },
+  info: {
+    icon: <Info size={18} strokeWidth={2.2} />,
+    accent: "#2b7fff",
+    iconBg: "rgba(43, 127, 255, 0.15)",
+    label: "Info",
+  },
+};
+
+// ── Custom toast content ──────────────────────────────────────────────────────
+
+function NexusToastContent({ message, type, closeToast }: NexusToastContentProps) {
+  const { icon, accent, iconBg, label } = CONFIG[type];
+
+  return (
+    <div className="nexus-toast-inner" data-type={type} style={{ "--nexus-accent": accent } as React.CSSProperties}>
+      {/* Left accent bar */}
+      <span className="nexus-toast-accent-bar" />
+
+      {/* Icon pill */}
+      <span
+        className="nexus-toast-icon"
+        style={{ background: iconBg, color: accent }}
+        aria-hidden
+      >
+        {icon}
+      </span>
+
+      {/* Text */}
+      <div className="nexus-toast-text">
+        <p className="nexus-toast-label">{label}</p>
+        <p className="nexus-toast-message">{message}</p>
+      </div>
+
+      {/* Close button */}
+      <button
+        className="nexus-toast-close"
+        onClick={closeToast}
+        aria-label="Dismiss notification"
+      >
+        <X size={14} strokeWidth={2.5} />
+      </button>
+    </div>
+  );
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS: ToastOptions = {
+  autoClose: 4000,
+  hideProgressBar: false,
+  closeButton: false,
+  icon: false,
+};
+
+export const nexusToast = {
+  success: (message: string, options?: ToastOptions) =>
+    toast(
+      ({ closeToast }) => (
+        <NexusToastContent message={message} type="success" closeToast={closeToast} />
+      ),
+      { ...DEFAULT_OPTIONS, ...options }
+    ),
+
+  error: (message: string, options?: ToastOptions) =>
+    toast(
+      ({ closeToast }) => (
+        <NexusToastContent message={message} type="error" closeToast={closeToast} />
+      ),
+      { ...DEFAULT_OPTIONS, ...options }
+    ),
+
+  warning: (message: string, options?: ToastOptions) =>
+    toast(
+      ({ closeToast }) => (
+        <NexusToastContent message={message} type="warning" closeToast={closeToast} />
+      ),
+      { ...DEFAULT_OPTIONS, ...options }
+    ),
+
+  info: (message: string, options?: ToastOptions) =>
+    toast(
+      ({ closeToast }) => (
+        <NexusToastContent message={message} type="info" closeToast={closeToast} />
+      ),
+      { ...DEFAULT_OPTIONS, ...options }
+    ),
+};

--- a/apps/nexus-web/src/features/card-activation/hooks/useCardActivation.ts
+++ b/apps/nexus-web/src/features/card-activation/hooks/useCardActivation.ts
@@ -8,7 +8,7 @@
 
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { activateCard } from "../api/activateCard";
 import type { CardActivationError } from "../types";
 

--- a/apps/nexus-web/src/features/members/components/MemberList.tsx
+++ b/apps/nexus-web/src/features/members/components/MemberList.tsx
@@ -8,7 +8,7 @@ import { GdgMember, GdgMemberUpdate } from "../types";
 import { Pagination } from "./ui/Pagination";
 import { MemberDetailsModal, MemberFormModal } from "./MemberModals";
 import { MemberCard } from "./MemberCard";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 
 export const MemberList: React.FC = () => {
   const [page, setPage] = useState(1);

--- a/apps/nexus-web/src/features/onboarding/hooks/useOnboardingForm.ts
+++ b/apps/nexus-web/src/features/onboarding/hooks/useOnboardingForm.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallEndpointWithToken } from "@/hooks/useFetchWithToken";
 import { contract } from "@packages/nexus-api-contracts";

--- a/apps/nexus-web/src/features/sparkmates/components/ChangeEmailDialog.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/ChangeEmailDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";  
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { Modal } from "./ui/Modal"; 
 import { Input } from "./ui/Input";
 import { Button } from "./ui/Button";

--- a/apps/nexus-web/src/features/sparkmates/components/ChangePasswordDialog.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/ChangePasswordDialog.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Modal } from "./ui/Modal";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input"; 
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { useChangePasswordFinalize } from "../hooks/useChangePasswordFinalize";
 import { useChangePasswordInitiate } from "../hooks/useChangePasswordInitiate";
 

--- a/apps/nexus-web/src/features/sparkmates/components/ProjectDetailsView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/ProjectDetailsView.tsx
@@ -16,7 +16,7 @@ import { ProjectFormState } from "@/features/onboarding/types";
 import { viewIcon } from "@/features/sparkmates/components/SparkmatesOwnerView/icons/viewIcon";
 import { ProjectDeleteConfirmDialog } from "@/features/sparkmates/components/ProjectDeleteConfirmDialog";
 import { SparkmatesBrandedErrorScreen } from "@/features/sparkmates/components/SparkmatesBrandedErrorScreen";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { useRouter } from "next/navigation";
 import { GdgLoader } from "@/components/ui/loader";
 

--- a/apps/nexus-web/src/features/sparkmates/components/SettingsChangePasswordDialog.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SettingsChangePasswordDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Modal, Button, Text, Input } from "@packages/spark-ui";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { useChangePasswordInitiate } from "../hooks/useChangePasswordInitiate";
 import { useChangePasswordFinalize } from "../hooks/useChangePasswordFinalize";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/ProfileOwnerView.tsx
@@ -5,7 +5,7 @@ import { CosmosParticles, LoadingScreen } from "@/components/shared";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { useSparkmateProfile } from "../../hooks";
 import { SparkmatesSource } from "../../types";
 import { useUpdateSparkmateProfile } from "../../hooks/useUpdateSparkmateProfile";

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/ShareDropdown.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesOwnerView/components/ShareDropdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import {
   Dropdown,
   DropdownTrigger,

--- a/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SparkmatesPublicView/ProfilePublicView.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import { Button, Text } from "@packages/spark-ui";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { CosmosParticles, LoadingScreen } from "@/components/shared";
 import { ASSETS } from "@/lib/constants/assets";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";

--- a/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/sections/ProjectsSection.tsx
@@ -25,7 +25,7 @@ import { useDeleteMemberProject } from "@/features/sparkmates/hooks/useDeleteMem
 import { ProjectsManager } from "@/features/onboarding/components/ProjectsManager";
 import { ProjectFormState } from "@/features/onboarding/types";
 import { ProjectDeleteConfirmDialog } from "@/features/sparkmates/components/ProjectDeleteConfirmDialog";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { GdgLoader } from "@/components/ui/loader";
 
 const MAX_PROJECT_IMAGES = 4;

--- a/apps/nexus-web/src/features/sparkmates/hooks/useDeleteMemberProject.ts
+++ b/apps/nexus-web/src/features/sparkmates/hooks/useDeleteMemberProject.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { deleteMemberProject } from "../api";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";
 import { useCallEndpointWithToken } from "@/hooks/useFetchWithToken";

--- a/apps/nexus-web/src/features/sparkmates/hooks/useMemberProjects.ts
+++ b/apps/nexus-web/src/features/sparkmates/hooks/useMemberProjects.ts
@@ -10,7 +10,7 @@ import {
   reorderMemberProjects,
 } from "../api";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import type { ProjectFormState } from "@/features/onboarding/types";
 import { useCallEndpointWithToken } from "@/hooks/useFetchWithToken";
 

--- a/apps/nexus-web/src/features/sparkmates/hooks/useToggleNfcVisibility.ts
+++ b/apps/nexus-web/src/features/sparkmates/hooks/useToggleNfcVisibility.ts
@@ -4,7 +4,7 @@ import { contract } from "@packages/nexus-api-contracts";
 import { configs } from "@/lib/constants/configs";
 import { extractErrorMessage } from "@/lib/utils";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 
 export const useToggleNfcVisibility = (gdgId: string) => {
   const queryClient = useQueryClient();

--- a/apps/nexus-web/src/features/sparkmates/hooks/useUpdateSparkmateProfile.ts
+++ b/apps/nexus-web/src/features/sparkmates/hooks/useUpdateSparkmateProfile.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateSparkmateProfile } from "../api";
 import type { UserProfile } from "../types";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 import { useCallEndpointWithToken } from "@/hooks/useFetchWithToken";
 
 export function useUpdateSparkmateProfile(gdgId?: string) {

--- a/apps/nexus-web/src/features/sparkmates/hooks/useUploadProfileImage.ts
+++ b/apps/nexus-web/src/features/sparkmates/hooks/useUploadProfileImage.ts
@@ -4,7 +4,7 @@ import { contract } from "@packages/nexus-api-contracts";
 import { configs } from "@/lib/constants/configs";
 import { extractErrorMessage } from "@/lib/utils";
 import { useAuthContext } from "@/features/authentication/store/useAuthStore";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/nexus-toast";
 
 export const useUploadProfileImage = (gdgId: string) => {
   const queryClient = useQueryClient();

--- a/apps/nexus-web/src/lib/nexus-toast.ts
+++ b/apps/nexus-web/src/lib/nexus-toast.ts
@@ -1,0 +1,10 @@
+/**
+ * @file nexus-toast.ts
+ * @description Drop-in replacement for react-toastify's `toast` helper.
+ *
+ * Usage — identical to react-toastify, just change the import:
+ *   import { toast } from "@/lib/nexus-toast";
+ *   toast.success("Done!") / toast.error("Oops!") / toast.info(...) / toast.warning(...)
+ */
+
+export { nexusToast as toast } from "@/components/shared/NexusToast";

--- a/apps/nexus-web/src/providers/ProviderCompose.tsx
+++ b/apps/nexus-web/src/providers/ProviderCompose.tsx
@@ -3,6 +3,8 @@ import { QueryProvider } from "@packages/spark-tools/query";
 import React from "react";
 import { LenisProvider } from "./LenisProvider";
 import { SessionManagementWrapper } from "./SessionManagementWrapper";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export const ProviderCompose = ({
   children,
@@ -13,7 +15,16 @@ export const ProviderCompose = ({
     <QueryProvider>
       <LenisProvider>
         <AuthContextProvider>
-          <SessionManagementWrapper>{children}</SessionManagementWrapper>
+          <SessionManagementWrapper>
+            {children}
+            <ToastContainer 
+              position="bottom-right" 
+              theme="dark"
+              closeButton={false}
+              hideProgressBar={false}
+              autoClose={4000}
+            />
+          </SessionManagementWrapper>
         </AuthContextProvider>
       </LenisProvider>
     </QueryProvider>


### PR DESCRIPTION
Closes #1197
This pull request introduces a custom Nexus-branded toast notification system to replace the default React-Toastify toasts throughout the application. The new system provides a unified, branded toast UI, custom animations, and type-specific styling, and updates all usages to import and use the new toast API.

**Key changes:**

### 1. Introduction of Custom Toast System

* Added a new `NexusToast` component and API in `apps/nexus-web/src/components/shared/NexusToast.tsx`, providing branded toast notifications with custom icons, accent colors, and close buttons for each toast type (`success`, `error`, `warning`, `info`).

### 2. Styling and Animation

* Added extensive custom CSS in `apps/nexus-web/src/app/globals.css` to style toast notifications, including custom entry/exit animations, hover effects, progress bar gradients, and per-type accent colors to match the Nexus brand.

### 3. Application-wide Migration

* Replaced all imports and usages of `toast` from `react-toastify` with the new Nexus-branded toast API (`@/lib/nexus-toast`) across all relevant files, including feature hooks, components, and pages. ([apps/nexus-web/src/app/activate/[cardUid]/page.tsxL17-R17](diffhunk://#diff-975823597a09576dd3f7cf41fbfef272681133930389c4bdc3d9f1f157b7de49L17-R17), [apps/nexus-web/src/app/nfc-cards/[cardId]/activate/page.tsxL17-R17](diffhunk://#diff-9705f20881ace23c52b0c52a93476e8fd1f280639505677d23d6168a41add85aL17-R17), [[1]](diffhunk://#diff-960f1fcd698b8a3c1526d35d184e313bbfecd3f2a1127e501ceeb2db08e0dacaL44-R44) [[2]](diffhunk://#diff-5fb6f2e82d1af27b0d38c8c7f435e2fcd2ded9a6130ddc87ed69e2f85c138c00L11-R11) [[3]](diffhunk://#diff-a6bcaeda96526819d036f6a565e2cb82ae491533f31a3dcd0c4d2486103c1d4cL11-R11) [[4]](diffhunk://#diff-3a4cdabf34b1ac1ada91e4cd507bdfff9492ba9e9429cbc1c0783963f2c7015eL3-R3) [[5]](diffhunk://#diff-a16c7ce3650fe9793f5fd6bf5ddcd8bde70f860fa63d10bd5cdc6cf238bd72b7L4-R4) [[6]](diffhunk://#diff-ad6622f348e7d04cafcf2fb0abd56df67f7bafa9fb4ce6c68520c7f067206f8aL7-R7) [[7]](diffhunk://#diff-c13c6f0110f5079528602f24601cc67c867cff7ad17886125847b58a907d6596L19-R19) [[8]](diffhunk://#diff-5068a0f1a6d7bc2a5b9361db0ac295aca10d4129505e9e46fcb871f47e5ae856L5-R5) [[9]](diffhunk://#diff-67119a62cd8ce7caeea57d696ca226a7074ff214f20ec1cda8f98c4c3fd7038fL8-R8) [[10]](diffhunk://#diff-68272a3f46af5dcfb0338b3e56a29e594dcb3d1c71c3c295a6fecfc73cf4d635L4-R4) [[11]](diffhunk://#diff-8c0305bde333c5ad7a3bc510bc1fa2a12c0e27450098d01be8fadd137f365b46L5-R5) [[12]](diffhunk://#diff-70ada52a56c11beb6ac5c6ff5c40c4ce7d847301e97219c4df2b29c21986e2adL28-R28) [[13]](diffhunk://#diff-2d1a170340b3053a15a3f831b6e4b216e464bfee7792d978659b78802e8616c3L3-R3) [[14]](diffhunk://#diff-2a07522bcd93631f0a8ad55ec98e5316e9e978e0c0601d11dfcac38af3579960L13-R13) [[15]](diffhunk://#diff-a1994e57b6472558eefa6e5f9074e2a28c5dd844e9d283469eb4199d625a9781L7-R7) [[16]](diffhunk://#diff-7e512ecc274e025f8f1ac5df8a54bb4ef55be4ceb3bd26d008a24a45e440b12dL4-R4)

These changes ensure toast notifications are visually consistent with the Nexus brand and provide a better user experience across the application.


<img width="462" height="179" alt="image" src="https://github.com/user-attachments/assets/4078edc9-0195-47bf-89ff-fbc5a2c26163" />
