### PR TITLE
fix(nexus-api): enhance global error handler with production-specific debug details

### DIFF
--- a/.github/workflows/ci.deploy.yml
+++ b/.github/workflows/ci.deploy.yml
@@ -129,6 +129,7 @@ jobs:
           env-vars: "ZEPTOMAIL_TOKEN=${{ secrets.ZEPTOMAIL_TOKEN }},\
             ZEPTOMAIL_FROM_ADDRESS=${{ secrets.ZEPTOMAIL_FROM_ADDRESS }},\
             ZEPTOMAIL_FROM_NAME=${{ secrets.ZEPTOMAIL_FROM_NAME }},\
+            DEV_MODE=${{ needs.detect-changes.outputs.environment == 'prod' && 'false' || 'true' }},\
             HIDE_API_DOCS=${{ vars.HIDE_API_DOCS || secrets.HIDE_API_DOCS || 'false' }},\
             FILE_STORAGE_MAIN_PROVIDER=${{ vars.FILE_STORAGE_MAIN_PROVIDER || 'gcs' }},\
             GCP_PROJECT_ID=${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'gdgpup-484914' }},\

--- a/apps/nexus-api/src/v0/middlewares/error.middleware.ts
+++ b/apps/nexus-api/src/v0/middlewares/error.middleware.ts
@@ -11,10 +11,10 @@ export const globalErrorHandler = (
   res: Response,
   next: NextFunction,
 ) => {
-  const isProd = process.env.NODE_ENV === "production";
+  const isDev = process.env.DEV_MODE === "true";
 
   const buildDebugDetails = (details: Record<string, unknown>) => {
-    return isProd ? undefined : details;
+    return isDev ? details : undefined;
   };
 
   // 1. Default values

--- a/apps/nexus-api/src/v0/middlewares/error.middleware.ts
+++ b/apps/nexus-api/src/v0/middlewares/error.middleware.ts
@@ -11,6 +11,12 @@ export const globalErrorHandler = (
   res: Response,
   next: NextFunction,
 ) => {
+  const isProd = process.env.NODE_ENV === "production";
+
+  const buildDebugDetails = (details: Record<string, unknown>) => {
+    return isProd ? undefined : details;
+  };
+
   // 1. Default values
   let statusCode = err.statusCode || 500;
   let message = err.message || "An unexpected error occurred.";
@@ -65,6 +71,10 @@ export const globalErrorHandler = (
   }
 
   if (err instanceof ServerError_DEPRECATED) {
+    const debugDetails = buildDebugDetails({
+      context: err.context.reverse().join(" -> "),
+    });
+
     return res.status(err.statusCode).json({
       status: err.status,
       message: err.message,
@@ -72,15 +82,19 @@ export const globalErrorHandler = (
         {
           title: err.title,
           detail: err.detail,
-          moreDetails: {
-            context: err.context.reverse().join(" -> "),
-          },
+          ...(debugDetails ? { moreDetails: debugDetails } : {}),
         },
       ],
     });
   }
 
   if (err instanceof HttpError) {
+    const debugDetails = buildDebugDetails({
+      last_error_stack: err.stack,
+      all_error_stack: err.getAllErrorStack(),
+      name: err.name,
+    });
+
     return res.status(err.statusCode).json({
       status: "fail",
       message: "HTTP Error",
@@ -88,17 +102,19 @@ export const globalErrorHandler = (
         {
           title: err.title,
           detail: err.detail,
-          moreDetails: {
-            last_error_stack: err.stack,
-            all_error_stack: err.getAllErrorStack(),
-            name: err.name,
-          },
+          ...(debugDetails ? { moreDetails: debugDetails } : {}),
         },
       ],
     });
   }
 
   if (err instanceof ServerError) {
+    const debugDetails = buildDebugDetails({
+      last_error_stack: err.stack,
+      all_error_stack: err.getAllErrorStack(),
+      name: err.name,
+    });
+
     return res.status(500).json({
       errors: [
         {
@@ -108,11 +124,7 @@ export const globalErrorHandler = (
             {
               title: err.title,
               detail: err.detail,
-              moreDetails: {
-                last_error_stack: err.stack,
-                all_error_stack: err.getAllErrorStack(),
-                name: err.name,
-              },
+              ...(debugDetails ? { moreDetails: debugDetails } : {}),
             },
           ],
         },
@@ -121,6 +133,8 @@ export const globalErrorHandler = (
   }
 
   if (err instanceof Error) {
+    const debugDetails = buildDebugDetails({ stack: err.stack });
+
     return res.status(500).json({
       errors: [
         {
@@ -130,9 +144,7 @@ export const globalErrorHandler = (
             {
               title: err.name,
               detail: err.message,
-              moreDetails: {
-                stack: err.stack,
-              },
+              ...(debugDetails ? { moreDetails: debugDetails } : {}),
             },
           ],
         },

--- a/apps/nexus-api/src/v1/middlewares/error.middleware.ts
+++ b/apps/nexus-api/src/v1/middlewares/error.middleware.ts
@@ -13,6 +13,12 @@ export const globalErrorHandler = (
   res: Response,
   next: NextFunction,
 ) => {
+  const isProd = process.env.NODE_ENV === "production";
+
+  const buildDebugDetails = (details: Record<string, unknown>) => {
+    return isProd ? undefined : details;
+  };
+
   // 1. Default values
   let statusCode = err.statusCode || 500;
   let message = err.message || "An unexpected error occurred.";
@@ -53,7 +59,7 @@ export const globalErrorHandler = (
         {
           title: err.name,
           message: err.message,
-          stack: err.stack,
+          ...(isProd ? {} : { stack: err.stack }),
         },
       ],
     });
@@ -104,6 +110,12 @@ export const globalErrorHandler = (
   }
 
   if (err instanceof HttpError) {
+    const debugDetails = buildDebugDetails({
+      last_error_stack: err.stack,
+      all_error_stack: err.getAllErrorStack(),
+      name: err.name,
+    });
+
     return res.status(err.statusCode).json({
       status: "fail",
       message: "HTTP Error",
@@ -111,17 +123,19 @@ export const globalErrorHandler = (
         {
           title: err.title,
           detail: err.detail,
-          moreDetails: {
-            last_error_stack: err.stack,
-            all_error_stack: err.getAllErrorStack(),
-            name: err.name,
-          },
+          ...(debugDetails ? { moreDetails: debugDetails } : {}),
         },
       ],
     });
   }
 
   if (err instanceof ServerError) {
+    const debugDetails = buildDebugDetails({
+      last_error_stack: err.stack,
+      all_error_stack: err.getAllErrorStack(),
+      name: err.name,
+    });
+
     return res.status(500).json({
       errors: [
         {
@@ -131,11 +145,7 @@ export const globalErrorHandler = (
             {
               title: err.title,
               detail: err.detail,
-              moreDetails: {
-                last_error_stack: err.stack,
-                all_error_stack: err.getAllErrorStack(),
-                name: err.name,
-              },
+              ...(debugDetails ? { moreDetails: debugDetails } : {}),
             },
           ],
         },
@@ -144,6 +154,8 @@ export const globalErrorHandler = (
   }
 
   if (err instanceof Error) {
+    const debugDetails = buildDebugDetails({ stack: err.stack });
+
     return res.status(500).json({
       errors: [
         {
@@ -153,9 +165,7 @@ export const globalErrorHandler = (
             {
               title: err.name,
               detail: err.message,
-              moreDetails: {
-                stack: err.stack,
-              },
+              ...(debugDetails ? { moreDetails: debugDetails } : {}),
             },
           ],
         },

--- a/apps/nexus-api/src/v1/middlewares/error.middleware.ts
+++ b/apps/nexus-api/src/v1/middlewares/error.middleware.ts
@@ -13,10 +13,10 @@ export const globalErrorHandler = (
   res: Response,
   next: NextFunction,
 ) => {
-  const isProd = process.env.NODE_ENV === "production";
+  const isDev = process.env.DEV_MODE === "true";
 
   const buildDebugDetails = (details: Record<string, unknown>) => {
-    return isProd ? undefined : details;
+    return isDev ? details : undefined;
   };
 
   // 1. Default values
@@ -59,7 +59,7 @@ export const globalErrorHandler = (
         {
           title: err.name,
           message: err.message,
-          ...(isProd ? {} : { stack: err.stack }),
+          ...(isDev ? { stack: err.stack } : {}),
         },
       ],
     });


### PR DESCRIPTION
This pull request improves the global error handling middleware in both the `v0` and `v1` versions of the Nexus API by making error debug details conditional based on the environment. Now, sensitive debug information is only included in error responses when not in production, enhancing security while maintaining useful debugging information during development.

Key changes include:

**Conditional Debug Information:**

* Introduced the `buildDebugDetails` helper function to only include debug details (like stack traces and error context) in error responses when not in production (`NODE_ENV !== "production"`). This function is now used throughout the error handler for all error types. [[1]](diffhunk://#diff-3a182707f4fb1a99155170c7b7234061b232e7f45058079ecdda9dd77235a418R14-R19) [[2]](diffhunk://#diff-ea6264fbbf7d0cbbbd6f53182323103da9a96176f39ba57894db52f4c0742cbbR16-R21)

* Updated error responses for `ServerError_DEPRECATED`, `HttpError`, `ServerError`, and generic `Error` instances to use the new `buildDebugDetails` function, ensuring that `moreDetails` or `stack` fields are only present in non-production environments. [[1]](diffhunk://#diff-3a182707f4fb1a99155170c7b7234061b232e7f45058079ecdda9dd77235a418R74-R117) [[2]](diffhunk://#diff-3a182707f4fb1a99155170c7b7234061b232e7f45058079ecdda9dd77235a418L111-R127) [[3]](diffhunk://#diff-3a182707f4fb1a99155170c7b7234061b232e7f45058079ecdda9dd77235a418R136-R137) [[4]](diffhunk://#diff-3a182707f4fb1a99155170c7b7234061b232e7f45058079ecdda9dd77235a418L133-R147) [[5]](diffhunk://#diff-ea6264fbbf7d0cbbbd6f53182323103da9a96176f39ba57894db52f4c0742cbbR113-R138) [[6]](diffhunk://#diff-ea6264fbbf7d0cbbbd6f53182323103da9a96176f39ba57894db52f4c0742cbbL134-R148) [[7]](diffhunk://#diff-ea6264fbbf7d0cbbbd6f53182323103da9a96176f39ba57894db52f4c0742cbbR157-R158) [[8]](diffhunk://#diff-ea6264fbbf7d0cbbbd6f53182323103da9a96176f39ba57894db52f4c0742cbbL156-R168)

* In the `v1` error handler, simplified the inclusion of the `stack` property for generic errors to only show in non-production environments.

These changes help prevent sensitive error details from leaking in production while retaining them for local development and testing.