### PR TITLE
fix(nexus-api): standardize unauthorized error messages in login execution

### DIFF
--- a/apps/nexus-api/src/v1/modules/authentication/useCases/Login.ts
+++ b/apps/nexus-api/src/v1/modules/authentication/useCases/Login.ts
@@ -19,9 +19,10 @@ export class Login {
   ) {}
 
   async execute(email: string, password: string): Promise<string> {
+    const genericAuthError = "Invalid email or password.";
     const credential = await this.credentialRepo.findByEmail(email);
     if (!credential) {
-      throw new UnauthorizedError("No account found with the provided email address.");
+      throw new UnauthorizedError(genericAuthError);
     }
 
     const isPasswordValid = await this.encryptionService.compare(
@@ -29,7 +30,7 @@ export class Login {
       credential.props.passwordHash,
     );
     if (!isPasswordValid) {
-      throw new UnauthorizedError("The password that you entered is incorrect.");
+      throw new UnauthorizedError(genericAuthError);
     }
 
     const permissions = await this.rbacService.listPermissionsOfUser(email);


### PR DESCRIPTION
This pull request updates the error handling in the `Login` use case to provide a more generic and secure authentication error message. Instead of revealing whether the email or password was incorrect, both error cases now return the same message.

Error handling improvements:

* Updated the `Login` use case in `Login.ts` to throw a generic authentication error message ("Invalid email or password.") for both invalid email and invalid password cases, improving security by not disclosing which credential failed.
