### PR TITLE
fix(nexus-api): standardize password field naming and validation across authentication components

### DIFF
--- a/apps/nexus-admin-web/src/features/authentication/components/LoginForm.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/components/LoginForm.tsx
@@ -43,9 +43,11 @@ export const LoginForm = () => {
             </div>
             <input
               id="email"
+              name="email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
+              autoComplete="username"
               required
               className="block w-full pl-10 pr-3 py-2.5 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
               placeholder="name@example.com"
@@ -72,9 +74,11 @@ export const LoginForm = () => {
             </div>
             <input
               id="password"
+              name="password"
               type={showPassword ? "text" : "password"}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
               required
               className="block w-full pl-10 pr-10 py-2.5 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
               placeholder="••••••••"

--- a/apps/nexus-admin-web/src/features/authentication/hooks/useLogin.ts
+++ b/apps/nexus-admin-web/src/features/authentication/hooks/useLogin.ts
@@ -6,7 +6,7 @@ import { extractErrorMessage } from "@/lib/utils";
 
 export const useLogin = () => {
   return useMutation({
-    mutationFn: async (payload: { email: string; pass: string }) => {
+    mutationFn: async (payload: { email: string; password: string }) => {
       const res = await callEndpoint(
         configs.nexusApiBaseUrl,
         contract.api.v1.authentication.login.POST,
@@ -14,7 +14,7 @@ export const useLogin = () => {
           body: {
             data: {
               email: payload.email,
-              pass: payload.pass,
+              password: payload.password,
             },
           },
         },

--- a/apps/nexus-admin-web/src/features/authentication/store/useAuthStore.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/store/useAuthStore.tsx
@@ -179,7 +179,7 @@ export const AuthContextProvider = ({
           body: {
             data: {
               email: email,
-              pass: password,
+              password: password,
             },
           },
         },

--- a/apps/nexus-api/src/v1/routes/authentication/authentication.controller.ts
+++ b/apps/nexus-api/src/v1/routes/authentication/authentication.controller.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from "express";
 import { AuthenticationController as AuthModuleController } from "@/v1/modules/authentication/AuthenticationController.js";
 import { contract } from "@packages/nexus-api-contracts";
 import { createExpressController } from "@packages/typed-rest/serverExpress";
+import { BadRequestError } from "@/v1/errors/HttpError.js";
 
 export class AuthenticationHttpController {
   constructor(private readonly moduleController: AuthModuleController) {}
@@ -51,8 +52,13 @@ export class AuthenticationHttpController {
   public login: RequestHandler = createExpressController(
     contract.api.v1.authentication.login.POST,
     async ({ input, output }) => {
-      const { email, pass } = input.body.data;
-      const result = await this.moduleController.login({ email, pass });
+      const { email, password, pass } = input.body.data;
+      const resolvedPassword = password ?? pass;
+      if (!resolvedPassword) {
+        throw new BadRequestError("Password is required.");
+      }
+
+      const result = await this.moduleController.login({ email, pass: resolvedPassword });
       
       return output(200, {
         status: "success",

--- a/apps/nexus-web/src/features/authentication/components/LoginForm.tsx
+++ b/apps/nexus-web/src/features/authentication/components/LoginForm.tsx
@@ -43,9 +43,11 @@ export const LoginForm = () => {
           <StyledInputContainer>
             <Input
               id="email"
+              name="email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
+              autoComplete="username"
               required
               containerClassName={inputBaseStyles}
               className="text-[18px] text-white placeholder:text-[#737373]"
@@ -66,9 +68,11 @@ export const LoginForm = () => {
           <StyledInputContainer>
             <Input
               id="password"
+              name="password"
               type={showPassword ? "text" : "password"}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
               required
               containerClassName={inputBaseStyles}
               className="text-[18px] text-white placeholder:text-[#737373]"

--- a/apps/nexus-web/src/features/authentication/hooks/useLogin.ts
+++ b/apps/nexus-web/src/features/authentication/hooks/useLogin.ts
@@ -7,7 +7,7 @@ import { useCallEndpointWithToken } from "@/hooks/useFetchWithToken";
 export const useLogin = () => {
   const callEndpoint = useCallEndpointWithToken();
   return useMutation({
-    mutationFn: async (payload: { email: string; pass: string }) => {
+    mutationFn: async (payload: { email: string; password: string }) => {
       const res = await callEndpoint(
         configs.nexusApiBaseUrl,
         contract.api.v1.authentication.login.POST,
@@ -15,7 +15,7 @@ export const useLogin = () => {
           body: {
             data: {
               email: payload.email,
-              pass: payload.pass,
+              password: payload.password,
             },
           },
         },

--- a/apps/nexus-web/src/features/authentication/store/useAuthStore.tsx
+++ b/apps/nexus-web/src/features/authentication/store/useAuthStore.tsx
@@ -169,7 +169,7 @@ export const AuthContextProvider = ({
           body: {
             data: {
               email: email,
-              pass: password,
+              password: password,
             },
           },
         },

--- a/packages/nexus-api-contracts/src/models/v1/authentication/schemas.ts
+++ b/packages/nexus-api-contracts/src/models/v1/authentication/schemas.ts
@@ -20,7 +20,11 @@ export const finalizeCreateNewUserResponse = z.object({
 
 export const loginRequest = z.object({
   email: z.string().email(),
-  pass: z.string(),
+  password: z.string().min(1).optional(),
+  pass: z.string().min(1).optional(),
+}).refine((data) => Boolean(data.password || data.pass), {
+  message: "Password is required",
+  path: ["password"],
 });
 
 export const loginResponse = z.object({


### PR DESCRIPTION
This pull request updates the authentication flow across both the Nexus Admin and Nexus Web applications to standardize the login payload by using `password` instead of `pass`, improves form accessibility and autofill by adding proper input attributes, and enhances backend compatibility and validation. The backend now accepts both `password` and legacy `pass` fields for login, but enforces that at least one is present.

**Frontend changes (Admin & Web):**

- **Login form improvements:**
  * Added `name` and `autoComplete` attributes to the email and password fields in both `LoginForm.tsx` components to improve accessibility and browser autofill. [[1]](diffhunk://#diff-698e588cda345e6f17e94e124da41c9651308ce2ba1ea8b152926930398f1c02R46-R50) [[2]](diffhunk://#diff-698e588cda345e6f17e94e124da41c9651308ce2ba1ea8b152926930398f1c02R77-R81) [[3]](diffhunk://#diff-c96bc6dd6cbfaef96fce3721a8dba19d3d3b1eacac29983b7ce918eb45f95e55R46-R50) [[4]](diffhunk://#diff-c96bc6dd6cbfaef96fce3721a8dba19d3d3b1eacac29983b7ce918eb45f95e55R71-R75)

- **Payload standardization:**
  * Updated login mutations and authentication store logic to use `password` instead of `pass` in both apps, ensuring consistency in API requests. [[1]](diffhunk://#diff-bf8223230dd74ae870c884d2ece98bef2190225caeb435af38cf81a728eddf53L9-R17) [[2]](diffhunk://#diff-d07c38bee95dfaf36ff2f410a9b4c475a2a62d24681e07916ee55aad18538f96L182-R182) [[3]](diffhunk://#diff-abbb7e862249a4816b74e939f0b0d4a390b813da701e4fe2140b53c57503a082L10-R18) [[4]](diffhunk://#diff-53539f915ec0d1d7583a18069a2e6c113d928fdacde3ab052ee767932eeeed34L172-R172)

**Backend changes (API & Contracts):**

- **API contract update:**
  * Modified the `loginRequest` schema to accept both `password` and `pass` (both optional but at least one required), with improved validation and error messaging.

- **Controller compatibility:**
  * Updated the login controller to support both `password` and `pass` fields, resolve which to use, and return a `BadRequestError` if neither is provided. [[1]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daR5) [[2]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL54-R61)