### PR TITLE
refactor(nexus-web): update CTA styles and improve text presentation

### DIFF
--- a/apps/nexus-web/src/features/home/components/hero-section.tsx
+++ b/apps/nexus-web/src/features/home/components/hero-section.tsx
@@ -177,7 +177,6 @@ export function HeroSection() {
           disableParallax={disableParallax}
         />
       ))}
-
       {/* CTA overlay — above all layers */}
       <motion.div
         style={{ opacity: ctaOpacity, y: prefersReduced ? 0 : ctaY }}
@@ -202,23 +201,33 @@ export function HeroSection() {
                   as="h1"
                   variant={headingVariant}
                   align="center"
-                  gradient="white-blue"
-                  weight="bold"
-                  className="leading-tight"
+                  weight="normal"
+                  className="leading-[1.05] text-white [text-shadow:0_10px_28px_rgba(0,0,0,0.95)]"
+                  style={{
+                    textShadow:
+                      "0 2px 4px rgba(0, 0, 0, 0.95), 0 8px 24px rgba(0, 0, 0, 0.95), 0 16px 48px rgba(0, 0, 0, 0.85)",
+                  }}
                 >
-                  Bridging the gap between theory and practice.
+                  <span className="block">Bridging the gap between</span>
+                  <span className="block font-semibold">
+                    theory and practice.
+                  </span>
                 </Text>
               </motion.div>
 
               <motion.div
                 variants={prefersReduced ? undefined : ctaItemVariants}
-                className="mt-4"
+                className="mt-6 md:mt-8"
               >
                 <Text
                   variant={bodyVariant}
                   align="center"
-                  weight="bold"
-                  className="text-white max-w-[54ch] mx-auto leading-relaxed"
+                  weight="normal"
+                  className="text-slate-100/90 max-w-[52ch] mx-auto leading-relaxed [text-shadow:0_8px_22px_rgba(0,0,0,0.9)]"
+                  style={{
+                    textShadow:
+                      "0 2px 4px rgba(0, 0, 0, 0.9), 0 6px 18px rgba(0, 0, 0, 0.9)",
+                  }}
                 >
                   GDG PUP helps student developers grow through real projects,
                   events, and mentorship connecting classroom learning to
@@ -228,7 +237,7 @@ export function HeroSection() {
 
               <motion.div
                 variants={prefersReduced ? undefined : ctaItemVariants}
-                className="mt-6 md:mt-8 inline-block"
+                className="mt-8 md:mt-10 inline-block"
               >
                 <Button asChild variant="default" size={ctaButtonSize}>
                   <Link prefetch={false} href="/signin">Spark your Journey</Link>


### PR DESCRIPTION
This pull request makes several visual and stylistic improvements to the `HeroSection` component in `hero-section.tsx`, focusing on enhancing the headline and call-to-action (CTA) area for better readability and design consistency. The main changes involve updating text styles, layout spacing, and visual emphasis.

**Hero section headline and CTA improvements:**

* Updated the headline (`Text` component) to remove the gradient, use normal font weight, and add custom text shadow styling for improved readability against backgrounds. The headline is now split into two blocks, with "theory and practice" emphasized in bold.
* Modified the supporting text below the headline to use normal weight, adjusted max width, refined color and text shadow for better legibility, and increased spacing above it.
* Increased vertical spacing for the CTA button and supporting text to create a more balanced layout, especially on larger screens. [[1]](diffhunk://#diff-6090d4dd2a9576684dda8979e8435fb7fce4300f290bbdc11b971777bd6bf6fdL205-R230) [[2]](diffhunk://#diff-6090d4dd2a9576684dda8979e8435fb7fce4300f290bbdc11b971777bd6bf6fdL231-R240)

**Other minor adjustments:**

* No functional or logic changes were made; all updates are visual and related to styling/layout.

closes #1201 
