### PR TITLE
refactor(nexus-web): simplify text styling and correct heading capitalization for who are we

### DIFF
--- a/apps/nexus-web/src/features/home/components/who-are-we-section.tsx
+++ b/apps/nexus-web/src/features/home/components/who-are-we-section.tsx
@@ -10,8 +10,7 @@ import { FrostedContentContainer } from "./frosted-content-container";
 export function WhoAreWeSection() {
   const sectionRef = useRef(null);
   const isInView = useInView(sectionRef, { once: true, margin: "-100px" });
-  const rainbowGradientTextClass =
-    "bg-[linear-gradient(90deg,#EA4335_0%,#F9AB00_33%,#34A853_66%,#4285F4_100%)] bg-clip-text text-transparent font-bold";
+  const rainbowGradientTextClass = "text-white font-bold";
 
   return (
     <section className="relative z-30 pb-20 lg:py-34" ref={sectionRef}>
@@ -26,12 +25,11 @@ export function WhoAreWeSection() {
             <Text
               as="h2"
               align="center"
-              gradient="white-yellow"
               variant="heading-2"
               weight="bold"
-              className="mt-35 mb-4 lg:my-0"
+              className="mt-35 mb-4 lg:my-0 text-white"
             >
-              Who are we
+              Who Are We
             </Text>
           </motion.div>
 
@@ -78,11 +76,11 @@ export function WhoAreWeSection() {
                   <Text
                     as="h3"
                     align="left"
-                    gradient="blue"
                     variant="heading-5"
                     weight="bold"
+                    className="text-white"
                   >
-                    We are More Than a Student Organization
+                    We Are More Than a Student Organization
                   </Text>
 
                   <Text


### PR DESCRIPTION
This pull request updates the `WhoAreWeSection` component to standardize text styling and improve consistency in the section's appearance. The main changes include removing gradient text styles, ensuring all headings use white text, and updating heading capitalization for consistency.

**Styling and Consistency Improvements:**

* Removed gradient text classes and properties, replacing them with a plain white text style for improved readability and consistency (`rainbowGradientTextClass`, `Text` components). [[1]](diffhunk://#diff-85ba2b54826e4e0ff4c268a86aefcd5bf83276ebd576e8e361835fbc3f79c51aL13-R13) [[2]](diffhunk://#diff-85ba2b54826e4e0ff4c268a86aefcd5bf83276ebd576e8e361835fbc3f79c51aL29-R32) [[3]](diffhunk://#diff-85ba2b54826e4e0ff4c268a86aefcd5bf83276ebd576e8e361835fbc3f79c51aL81-R83)
* Updated heading text to use title case for a more polished and consistent look ("Who Are We", "We Are More Than a Student Organization"). [[1]](diffhunk://#diff-85ba2b54826e4e0ff4c268a86aefcd5bf83276ebd576e8e361835fbc3f79c51aL29-R32) [[2]](diffhunk://#diff-85ba2b54826e4e0ff4c268a86aefcd5bf83276ebd576e8e361835fbc3f79c51aL81-R83)

closes #1202  #1203