### PR TITLE
refactor(nexus-web): replace bullet images with colored spans and enhance text styles

### DIFF
--- a/apps/nexus-web/src/features/home/components/impact-section.tsx
+++ b/apps/nexus-web/src/features/home/components/impact-section.tsx
@@ -14,6 +14,7 @@ const buildWords = ["Creators", "Leaders", "Community"];
 export function ImpactSection() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const bulletColors = ["#4285F4", "#F9AB00", "#34A853", "#EA4335"];
 
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
 
@@ -73,9 +74,13 @@ export function ImpactSection() {
           <Text
             as="h2"
             align="center"
-            gradient="white-blue"
             variant="heading-2"
             weight="bold"
+            className="text-white"
+            style={{
+              textShadow:
+                "0 2px 4px rgba(0, 0, 0, 0.95), 0 8px 24px rgba(0, 0, 0, 0.95), 0 16px 48px rgba(0, 0, 0, 0.85)",
+            }}
           >
             The Impact
           </Text>
@@ -112,9 +117,9 @@ export function ImpactSection() {
               <Text
                 as="h5"
                 align="left"
-                gradient="white-yellow"
                 variant="heading-5"
                 weight="bold"
+                className="text-white"
               >
                 But beyond numbers, <br />
                 GDG PUP has helped students:
@@ -125,13 +130,10 @@ export function ImpactSection() {
                   ringClassName="w-133.5"
                 >
                   <Inline>
-                    <Image
-                      src={ASSETS.HOME.BULLET_DIAMOND}
-                      alt="bullet point"
-                      width={16}
-                      height={16}
-                      draggable={false}
-                      className="pointer-events-none select-none"
+                    <span
+                      aria-hidden
+                      className="h-2.5 w-2.5 rounded-full shrink-0"
+                      style={{ backgroundColor: bulletColors[0] }}
                     />
                     <Text
                       align="left"
@@ -150,13 +152,10 @@ export function ImpactSection() {
                   className="ml-8"
                 >
                   <Inline>
-                    <Image
-                      src={ASSETS.HOME.BULLET_DIAMOND}
-                      alt="bullet point"
-                      width={16}
-                      height={16}
-                      draggable={false}
-                      className="pointer-events-none select-none"
+                    <span
+                      aria-hidden
+                      className="h-2.5 w-2.5 rounded-full shrink-0"
+                      style={{ backgroundColor: bulletColors[1] }}
                     />
                     <Text
                       align="left"
@@ -175,13 +174,10 @@ export function ImpactSection() {
                   className="ml-16"
                 >
                   <Inline>
-                    <Image
-                      src={ASSETS.HOME.BULLET_DIAMOND}
-                      alt="bullet point"
-                      width={16}
-                      height={16}
-                      draggable={false}
-                      className="pointer-events-none select-none"
+                    <span
+                      aria-hidden
+                      className="h-2.5 w-2.5 rounded-full shrink-0"
+                      style={{ backgroundColor: bulletColors[2] }}
                     />
                     <Text
                       align="left"
@@ -200,13 +196,10 @@ export function ImpactSection() {
                   className="ml-24"
                 >
                   <Inline>
-                    <Image
-                      src={ASSETS.HOME.BULLET_DIAMOND}
-                      alt="bullet point"
-                      width={16}
-                      height={16}
-                      draggable={false}
-                      className="pointer-events-none select-none"
+                    <span
+                      aria-hidden
+                      className="h-2.5 w-2.5 rounded-full shrink-0"
+                      style={{ backgroundColor: bulletColors[3] }}
                     />
                     <Text
                       align="left"
@@ -278,10 +271,9 @@ export function ImpactSection() {
           <Text
             as="h5"
             align="center"
-            gradient="white-yellow"
             variant="heading-5"
             weight="bold"
-            className="text-3xl"
+            className="text-3xl text-white"
           >
             We don’t just host events...
           </Text>

--- a/apps/nexus-web/src/features/home/components/what-drives-us-section.tsx
+++ b/apps/nexus-web/src/features/home/components/what-drives-us-section.tsx
@@ -10,6 +10,7 @@ import { FrostedContentContainer } from "./frosted-content-container";
 export function WhatDrivesUsSection() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const bulletColors = ["#4285F4", "#F9AB00", "#34A853", "#EA4335"];
 
   return (
     <section className="relative z-30" ref={ref}>
@@ -39,9 +40,13 @@ export function WhatDrivesUsSection() {
             <Text
               as="h2"
               align="left"
-              gradient="white-green"
               weight="bold"
-              className="mb-0.5 text-4xl lg:text-[4rem] text-right lg:text-left w-full"
+              variant="heading-2"
+              className="mb-0.5 text-right lg:text-left w-full text-white"
+              style={{
+                textShadow:
+                  "0 2px 4px rgba(0, 0, 0, 0.95), 0 8px 24px rgba(0, 0, 0, 0.95), 0 16px 48px rgba(0, 0, 0, 0.85)",
+              }}
             >
               What drives us
             </Text>
@@ -52,20 +57,16 @@ export function WhatDrivesUsSection() {
                   align="left"
                   variant="heading-5"
                   weight="bold"
-                  gradient="white-yellow"
-                  className="text-2xl"
+                  className="text-2xl text-white"
                 >
                   We believe that:
                 </Text>
 
                 <Inline>
-                  <Image
-                    src={ASSETS.HOME.BULLET_DIAMOND}
-                    alt="bullet point"
-                    width={16}
-                    height={16}
-                    draggable={false}
-                    className="pointer-events-none select-none"
+                  <span
+                    aria-hidden
+                    className="h-2.5 w-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: bulletColors[0] }}
                   />
                   <Text
                     align="left"
@@ -79,13 +80,10 @@ export function WhatDrivesUsSection() {
                 </Inline>
 
                 <Inline>
-                  <Image
-                    src={ASSETS.HOME.BULLET_DIAMOND}
-                    alt="bullet point"
-                    width={16}
-                    height={16}
-                    draggable={false}
-                    className="pointer-events-none select-none"
+                  <span
+                    aria-hidden
+                    className="h-2.5 w-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: bulletColors[1] }}
                   />
                   <Text
                     align="left"
@@ -99,13 +97,10 @@ export function WhatDrivesUsSection() {
                 </Inline>
 
                 <Inline>
-                  <Image
-                    src={ASSETS.HOME.BULLET_DIAMOND}
-                    alt="bullet point"
-                    width={16}
-                    height={16}
-                    draggable={false}
-                    className="pointer-events-none select-none"
+                  <span
+                    aria-hidden
+                    className="h-2.5 w-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: bulletColors[2] }}
                   />
                   <Text
                     align="left"
@@ -119,13 +114,10 @@ export function WhatDrivesUsSection() {
                 </Inline>
 
                 <Inline>
-                  <Image
-                    src={ASSETS.HOME.BULLET_DIAMOND}
-                    alt="bullet point"
-                    width={16}
-                    height={16}
-                    draggable={false}
-                    className="pointer-events-none select-none"
+                  <span
+                    aria-hidden
+                    className="h-2.5 w-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: bulletColors[3] }}
                   />
                   <Text
                     align="left"

--- a/apps/nexus-web/src/features/home/components/what-we-do-section.tsx
+++ b/apps/nexus-web/src/features/home/components/what-we-do-section.tsx
@@ -10,6 +10,7 @@ import { FrostedContentContainer } from "./frosted-content-container";
 export function WhatWeDoSection() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const bulletColors = ["#4285F4", "#F9AB00", "#34A853", "#EA4335"];
   const bulletItems = [
     "Technical workshops powered by Google-backed tools and technologies",
     "Study Jams and skill-shares focused on hands-on learning",
@@ -31,10 +32,13 @@ export function WhatWeDoSection() {
             <Text
               as="h2"
               align="left"
-              gradient="white-green"
               variant="heading-2"
               weight="bold"
-              className="mb-0.5"
+              className="mb-0.5 text-white"
+              style={{
+                textShadow:
+                  "0 2px 4px rgba(0, 0, 0, 0.95), 0 8px 24px rgba(0, 0, 0, 0.95), 0 16px 48px rgba(0, 0, 0, 0.85)",
+              }}
             >
               What we do
             </Text>
@@ -45,10 +49,9 @@ export function WhatWeDoSection() {
                     <Text
                       as="h3"
                       align="left"
-                      gradient="white-yellow"
                       weight="bold"
                       color="on-primary"
-                      className="text-2xl"
+                      className="text-2xl text-white"
                     >
                       We design experiences that turn{" "}
                       <br className="hidden lg:inline" />
@@ -56,19 +59,18 @@ export function WhatWeDoSection() {
                     </Text>
                   </div>
                   <div className="flex flex-col gap-4">
-                    {bulletItems.map((item) => (
+                    {bulletItems.map((item, index) => (
                       <div
                         key={item}
-                        className="flex items-start gap-3 relative z-10"
+                        className="flex items-center gap-3 relative z-10"
                       >
-                        <Image
-                          src={ASSETS.HOME.BULLET_DIAMOND}
-                          alt=""
+                        <span
                           aria-hidden
-                          width={18}
-                          height={18}
-                          draggable={false}
-                          className="pointer-events-none select-none mt-1 shrink-0"
+                          className="h-2.5 w-2.5 rounded-full shrink-0"
+                          style={{
+                            backgroundColor:
+                              bulletColors[index % bulletColors.length],
+                          }}
                         />
                         <Text
                           align="left"


### PR DESCRIPTION
This pull request updates the bullet point styling and heading text styles across the `ImpactSection`, `WhatWeDoSection`, and `WhatDrivesUsSection` components for improved visual consistency and accessibility. The main changes include replacing image-based bullet points with accessible colored spans, standardizing heading colors and shadows, and removing gradient text styles.

**Bullet point style improvements:**
* Replaced diamond image bullet points with accessible, colored `span` elements using the new `bulletColors` array for all bullet lists in `ImpactSection`, `WhatWeDoSection`, and `WhatDrivesUsSection`. This improves accessibility and allows for easier color customization. [[1]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8L128-R136) [[2]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8L153-R158) [[3]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8L178-R180) [[4]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8L203-R202) [[5]](diffhunk://#diff-4f7cd0b9641c726beee586086db11e967f9c5705acace11a681e23bc7026804aL55-R69) [[6]](diffhunk://#diff-4f7cd0b9641c726beee586086db11e967f9c5705acace11a681e23bc7026804aL82-R86) [[7]](diffhunk://#diff-4f7cd0b9641c726beee586086db11e967f9c5705acace11a681e23bc7026804aL102-R103) [[8]](diffhunk://#diff-4f7cd0b9641c726beee586086db11e967f9c5705acace11a681e23bc7026804aL122-R120) [[9]](diffhunk://#diff-dfa0294e1b5ea6cbcbcb0d5cca086aa657b8c7d5f622121224410cf94b9190eaL48-R73)

**Heading and text style updates:**
* Removed gradient text styles from all major headings and replaced them with solid white text and a consistent text shadow for better readability and design consistency. [[1]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8L76-R83) [[2]](diffhunk://#diff-4f7cd0b9641c726beee586086db11e967f9c5705acace11a681e23bc7026804aL42-R49) [[3]](diffhunk://#diff-dfa0294e1b5ea6cbcbcb0d5cca086aa657b8c7d5f622121224410cf94b9190eaL34-R41)
* Updated subheading and bullet point text to use white color, improving contrast against backgrounds and maintaining consistency. [[1]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8L115-R122) [[2]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8L281-R276) [[3]](diffhunk://#diff-4f7cd0b9641c726beee586086db11e967f9c5705acace11a681e23bc7026804aL55-R69) [[4]](diffhunk://#diff-dfa0294e1b5ea6cbcbcb0d5cca086aa657b8c7d5f622121224410cf94b9190eaL48-R73)

**Code refactoring for color management:**
* Introduced a shared `bulletColors` array in each section component to centralize bullet color definitions and allow for easy reuse and updates. [[1]](diffhunk://#diff-f127ffb65ed4681d0cca099b95254eab2dddd8844b47fde86ae4b39e21cafac8R17) [[2]](diffhunk://#diff-4f7cd0b9641c726beee586086db11e967f9c5705acace11a681e23bc7026804aR13) [[3]](diffhunk://#diff-dfa0294e1b5ea6cbcbcb0d5cca086aa657b8c7d5f622121224410cf94b9190eaR13)

These changes collectively modernize the visual style and accessibility of the home page feature sections.

closes #1204 