### PR TITLE
refactor(nexus-web): update button color and replace bullet images with colored spans

### DIFF
--- a/apps/nexus-web/src/features/home/components/spark-starts-here-section.tsx
+++ b/apps/nexus-web/src/features/home/components/spark-starts-here-section.tsx
@@ -11,6 +11,7 @@ import { FrostedContentContainer } from "./frosted-content-container";
 export function SparkStartsHereSection() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const bulletColors = ["#4285F4", "#F9AB00", "#34A853", "#EA4335"];
 
   return (
     <section
@@ -50,8 +51,10 @@ export function SparkStartsHereSection() {
                   >
                     Your Spark Starts Here.
                   </Text>
-                  <Button asChild variant="colored" subVariant="yellow" size="lg">
-                  <Link prefetch={false} href="/signin">Spark your Journey</Link>
+                  <Button asChild variant="colored" subVariant="blue" size="lg">
+                    <Link prefetch={false} href="/signin">
+                      Spark your Journey
+                    </Link>
                   </Button>
                 </Stack>
 
@@ -73,13 +76,10 @@ export function SparkStartsHereSection() {
 
                   <Stack className="gap-3.5">
                     <Inline>
-                      <Image
-                        src={ASSETS.HOME.BULLET_DIAMOND}
-                        alt="bullet point"
-                        width={16}
-                        height={16}
-                        draggable={false}
-                        className="pointer-events-none select-none"
+                      <span
+                        aria-hidden
+                        className="h-2.5 w-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: bulletColors[0] }}
                       />
                       <Text
                         align="left"
@@ -93,13 +93,10 @@ export function SparkStartsHereSection() {
                     </Inline>
 
                     <Inline>
-                      <Image
-                        src={ASSETS.HOME.BULLET_DIAMOND}
-                        alt="bullet point"
-                        width={16}
-                        height={16}
-                        draggable={false}
-                        className="pointer-events-none select-none"
+                      <span
+                        aria-hidden
+                        className="h-2.5 w-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: bulletColors[1] }}
                       />
                       <Text
                         align="left"
@@ -113,13 +110,10 @@ export function SparkStartsHereSection() {
                     </Inline>
 
                     <Inline>
-                      <Image
-                        src={ASSETS.HOME.BULLET_DIAMOND}
-                        alt="bullet point"
-                        width={16}
-                        height={16}
-                        draggable={false}
-                        className="pointer-events-none select-none"
+                      <span
+                        aria-hidden
+                        className="h-2.5 w-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: bulletColors[2] }}
                       />
                       <Text
                         align="left"


### PR DESCRIPTION
This pull request updates the `SparkStartsHereSection` component in the homepage to improve visual consistency and accessibility. The main changes include replacing image-based bullet points with colored circular spans and updating the button color to better match the design.

Visual and UI improvements:

* Replaced the diamond-shaped bullet point images with colored circular `span` elements for each list item, using a new `bulletColors` array to provide distinct colors for each bullet. This change improves accessibility and visual consistency. [[1]](diffhunk://#diff-a2f5825998d38bf6f9b488537cb545ab40066787c9ed813696c8a189520cdb05R14) [[2]](diffhunk://#diff-a2f5825998d38bf6f9b488537cb545ab40066787c9ed813696c8a189520cdb05L76-R82) [[3]](diffhunk://#diff-a2f5825998d38bf6f9b488537cb545ab40066787c9ed813696c8a189520cdb05L96-R99) [[4]](diffhunk://#diff-a2f5825998d38bf6f9b488537cb545ab40066787c9ed813696c8a189520cdb05L116-R116)
* Changed the call-to-action button's color from yellow to blue by updating the `subVariant` property, aligning the button with the new color scheme.