### PR TITLE
refactor(nexus-web): update hover effect color for dropdown items

### DIFF
--- a/apps/nexus-web/src/components/shared/Navbar.tsx
+++ b/apps/nexus-web/src/components/shared/Navbar.tsx
@@ -37,7 +37,7 @@ const dropdownInnerClasses = cn(
 
 const dropdownItemClasses = cn(
   "block w-full text-left text-white font-bold transition-all p-3 rounded-lg",
-  "hover:bg-[linear-gradient(0deg,#57CAFF_0%,#347999_100%)] hover:!text-transparent hover:bg-clip-text",
+  "hover:text-[#4285F4]",
 );
 
 function useOutsideClick(callback: () => void) {


### PR DESCRIPTION
This pull request makes a small UI update to the `Navbar.tsx` component, specifically changing the hover effect for dropdown menu items to use a solid color instead of a gradient.

- Changed the dropdown menu item's hover effect to use a solid blue text color (`#4285F4`) instead of a gradient and transparent text. (`apps/nexus-web/src/components/shared/Navbar.tsx`)