### PR TITLE
refactor(nexus-web): disable modal functionality

### DIFF
--- a/apps/nexus-web/src/features/community-showcase/components/FeaturedEventCard.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/FeaturedEventCard.tsx
@@ -108,8 +108,8 @@ const TRUNCATED_ABOUT =
           <Stack gap="sm" className="flex-2">
             <button
               type="button"
-              onClick={onOpenModal}
-              className="text-left cursor-pointer group"
+              // Modal disabled for now; restore onClick={onOpenModal} when needed.
+              className="text-left group"
             >
               <Text
                 variant="body-lg"


### PR DESCRIPTION
This pull request makes a small change to the `FeaturedEventCard` component by disabling the modal functionality for now. The `onClick` handler is removed from the button, with a comment indicating it can be restored when needed.