### PR TITLE
refactor(nexus-web): simplify component styles

### DIFF
--- a/apps/nexus-web/src/features/community-showcase/components/DesktopShowcase.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/DesktopShowcase.tsx
@@ -31,7 +31,7 @@ export function DesktopShowcase({ onOpenModal, events }: DesktopShowcaseProps) {
         <div className="pointer-events-none w-241.5 h-244.25 left-0 top-0 absolute bg-sky-400/20 rounded-full blur-[400px] -translate-x-1/5 translate-y-3/4" />
         <div className="pointer-events-none w-241.5 h-244.25 left-0 bottom-0 absolute bg-pink-400/30 rounded-full blur-[400px] translate-x-1/2 translate-y-4/20" />
         <img
-          className="pointer-events-none z-20 w-[30vw] max-w-123.25 h-auto right-0 top-20 absolute -mr-[6vw]"
+          className="pointer-events-none z-11 w-[30vw] max-w-123.25 h-auto right-0 top-20 absolute -mr-[6vw]"
           src="/community-showcase/community-showcase-cirby.webp"
           alt=""
         />

--- a/apps/nexus-web/src/features/community-showcase/components/FeaturedEventCard.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/FeaturedEventCard.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 "use client";
 
-import { useState } from "react";
 import { Card, Stack, Text } from "@packages/spark-ui";
 import { Event } from "@/features/events";
 import { ASSETS } from "@/lib/constants/assets";
@@ -26,11 +25,6 @@ interface FeaturedEventCardProps {
 }
 
 export function FeaturedEventCard({ onOpenModal, event }: FeaturedEventCardProps) {
-  const [isCardHovered, setIsCardHovered] = useState(false);
-  const [is39Hovered, setIs39Hovered] = useState(false);
-
-
-
 const ABOUT_TEXT = normalizeEventDescription(event.description) || "No description available for this event.";
 
 const TRUNCATED_ABOUT =
@@ -41,9 +35,7 @@ const TRUNCATED_ABOUT =
       {/* Heading block — slides up on card hover */}
       <Stack
         gap="xs"
-        className={`z-10 transition-transform duration-1000 ease-out ${
-          isCardHovered ? "-translate-y-3" : "translate-y-0"
-        }`}
+        className="z-10"
       >
         <Text
           variant="heading-2"
@@ -83,25 +75,29 @@ const TRUNCATED_ABOUT =
 
       {/* Event image card with gradient border */}
       <div className="relative mt-15 flex w-full justify-center z-10">
-        <Card
-          variant="default"
-          className="w-full h-[clamp(200px,25vw,360px)] rounded-[32px] max-w-none p-1 bg-[linear-gradient(135deg,#EA4335,#F9AB00,#34A853,#4285F4)] shadow-[0px_10px_15px_0px_rgba(0,0,0,0.40)] overflow-hidden bg-transparent! border-0! z-10 transform transition-transform duration-1000 ease-out hover:rotate-[-1deg]"
-          onMouseEnter={() => setIsCardHovered(true)}
-          onMouseLeave={() => setIsCardHovered(false)}
-        >
-          <img
-            src={event.image_url || event.images?.[0] || ASSETS.PLACEHOLDERS.DEFAULT}
-            alt=""
-            className="w-full h-full object-cover rounded-[30px]"
-          />
-        </Card>
+        <div className="relative w-full max-w-none rounded-[32px] p-[2px] bg-[linear-gradient(135deg,#EA4335,#F9AB00,#34A853,#4285F4)] shadow-[0px_10px_15px_0px_rgba(0,0,0,0.40)] z-10">
+          <Card
+            variant="default"
+            className="w-full max-w-none aspect-[16/9] rounded-[30px] bg-[#0B0B0B] overflow-hidden border-0! p-3"
+          >
+            <img
+              src={event.image_url || event.images?.[0] || ASSETS.PLACEHOLDERS.DEFAULT}
+              alt=""
+              aria-hidden
+              className="absolute inset-0 h-full w-full object-cover blur-[18px] opacity-55"
+            />
+            <img
+              src={event.image_url || event.images?.[0] || ASSETS.PLACEHOLDERS.DEFAULT}
+              alt=""
+              className="relative w-full h-full object-contain rounded-[20px]"
+            />
+          </Card>
+        </div>
       </div>
 
       {/* About + Stats row — slides down on card hover */}
       <div
-        className={`relative w-full flex justify-center mt-10 z-10 transition-transform duration-1000 ease-out ${
-          isCardHovered ? "translate-y-5" : "translate-y-0"
-        }`}
+        className="relative w-full flex justify-center mt-10 z-10"
       >
         <div className="w-full flex flex-col md:flex-row gap-8">
           {/* About */}
@@ -109,17 +105,17 @@ const TRUNCATED_ABOUT =
             <button
               type="button"
               // Modal disabled for now; restore onClick={onOpenModal} when needed.
-              className="text-left group"
+              className="text-left"
             >
               <Text
                 variant="body-lg"
-                className="text-white transition-colors duration-200 group-hover:text-blue-500"
+                className="text-white"
               >
                 ABOUT THIS EVENT
               </Text>
               <Text
                 variant="body"
-                className="text-white leading-8 max-w-[55vw] xl:max-w-220 transition-colors duration-200 group-hover:text-blue-500"
+                className="text-white leading-8 max-w-[55vw] xl:max-w-220"
               >
                 {TRUNCATED_ABOUT}
               </Text>
@@ -136,36 +132,12 @@ const TRUNCATED_ABOUT =
           >
             {/* RSVP count */}
             <div>
-              <div
-                onMouseEnter={() => setIs39Hovered(true)}
-                onMouseLeave={() => setIs39Hovered(false)}
-                style={{
-                  display: "inline-block",
-                  transform: is39Hovered ? "rotate(-15.95deg)" : "rotate(0deg)",
-                  transition: "transform 1000ms ease-out",
-                }}
-              >
-                <Text
-                  variant="heading-2"
-                  className={is39Hovered ? "" : "text-white"}
-                  gradient={is39Hovered ? "white-blue" : undefined}
-                >
-                  {event.rsvp ?? event.attendees_count}
-                </Text>
-              </div>
-              <div
-                style={{
-                  transform: is39Hovered ? "translateY(20px)" : "translateY(0)",
-                  transition: "transform 1000ms ease-out",
-                }}
-              >
-                <Text
-                  variant="body"
-                  className="text-white leading-8 max-w-[600px]"
-                >
-                  RSVP&apos;d
-                </Text>
-              </div>
+              <Text variant="heading-2" className="text-white">
+                {event.rsvp ?? event.attendees_count}
+              </Text>
+              <Text variant="body" className="text-white leading-8 max-w-[600px]">
+                RSVP&apos;d
+              </Text>
             </div>
 
             {/* Category tag */}

--- a/apps/nexus-web/src/features/community-showcase/components/MobileShowcase.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/MobileShowcase.tsx
@@ -99,7 +99,7 @@ export function MobileShowcase({ events }: { events: Event[] }) {
         alt=""
       />
       <img
-        className="pointer-events-none w-[33vw] max-w-123.25 h-auto right-0 top-2 absolute -mr-[11vw] -z-10"
+        className="pointer-events-none w-[33vw] max-w-123.25 h-auto right-0 top-2 absolute -mr-[11vw] -z-20"
         src="/community-showcase/community-showcase-cirby.webp"
         alt=""
       />

--- a/apps/nexus-web/src/features/community-showcase/components/PlanetCard.tsx
+++ b/apps/nexus-web/src/features/community-showcase/components/PlanetCard.tsx
@@ -9,9 +9,9 @@
 
 const PLANET_MASK_STYLE: React.CSSProperties = {
   WebkitMaskImage:
-    "radial-gradient(ellipse 50% 50% at 50% 50%, black 50%, rgba(0, 0, 0, 0.35) 85%, rgba(0, 0, 0, 0) 100%)",
+    "radial-gradient(ellipse 55% 55% at 50% 50%, black 40%, rgba(0, 0, 0, 0.25) 75%, rgba(0, 0, 0, 0) 100%)",
   maskImage:
-    "radial-gradient(ellipse 50% 50% at 50% 50%, black 50%, rgba(0, 0, 0, 0.35) 85%, rgba(0, 0, 0, 0) 100%)",
+    "radial-gradient(ellipse 55% 55% at 50% 50%, black 40%, rgba(0, 0, 0, 0.25) 75%, rgba(0, 0, 0, 0) 100%)",
 };
 
 interface PlanetCardProps {
@@ -34,12 +34,19 @@ export function PlanetCard({
   return (
     <div className="relative" style={style ?? { width: size, height: size }}>
       {/* Sphere */}
-      <div className="relative h-full w-full overflow-hidden rounded-full bg-black">
+      <div className="relative h-full w-full overflow-hidden rounded-full bg-[#0B0B0B]">
+        <img
+          src={image}
+          alt=""
+          aria-hidden
+          draggable={false}
+          className="absolute inset-0 h-full w-full object-cover scale-125 blur-3xl opacity-90"
+        />
         <img
           src={image}
           alt={alt}
           draggable={draggable}
-          className="h-full w-full object-cover"
+          className="relative h-full w-full object-cover object-center rounded-full"
           style={PLANET_MASK_STYLE}
         />
         {/* Dark shadow — bottom-left */}


### PR DESCRIPTION
This pull request focuses on visual and interaction improvements to the community showcase components, especially the `FeaturedEventCard`, `PlanetCard`, and background image layering. The main changes simplify card hover logic, enhance image presentation, and adjust z-index layering for better visual hierarchy.

**UI and Visual Improvements:**

* Refactored `FeaturedEventCard` to remove hover-based animations and state, simplifying the component and making the layout static. The card now features a dual-layer event image with a blurred background and a centered, contained foreground image for a more polished look. [[1]](diffhunk://#diff-c6a23c53b018f0e26f951f5f5f5131d1553c855f34b209aa5bfc66002a8bd4cdL4) [[2]](diffhunk://#diff-c6a23c53b018f0e26f951f5f5f5131d1553c855f34b209aa5bfc66002a8bd4cdL29-L33) [[3]](diffhunk://#diff-c6a23c53b018f0e26f951f5f5f5131d1553c855f34b209aa5bfc66002a8bd4cdL44-R38) [[4]](diffhunk://#diff-c6a23c53b018f0e26f951f5f5f5131d1553c855f34b209aa5bfc66002a8bd4cdR78-R118) [[5]](diffhunk://#diff-c6a23c53b018f0e26f951f5f5f5131d1553c855f34b209aa5bfc66002a8bd4cdL139-L169)
* Updated `PlanetCard` to add a blurred, enlarged background image layer behind the main image, and tweaked the mask gradient for a softer edge. The background color was also changed to a darker shade for better contrast. [[1]](diffhunk://#diff-d299134a1529bbd754d8032872e905bc697f5da40e07b451fac7bbca68603830L12-R14) [[2]](diffhunk://#diff-d299134a1529bbd754d8032872e905bc697f5da40e07b451fac7bbca68603830L37-R49)

**Z-Index and Layering Adjustments:**

* Adjusted z-index values for background and foreground images in `DesktopShowcase` and `MobileShowcase` to ensure correct stacking order and visual clarity. [[1]](diffhunk://#diff-f94ffcbbbf7ee55fadf98e34ed348553a8ec56a457434d1f8d3a7f007948a263L34-R34) [[2]](diffhunk://#diff-331de50dc87238df224b8b3e9dd2a8a9f1944d1ff1f6ef755d61b7e8076847b2L102-R102)