### PR TITLE
refactor(nexus-web): update text colors in footer for better consistency

### DIFF
--- a/apps/nexus-web/src/components/shared/Footer.tsx
+++ b/apps/nexus-web/src/components/shared/Footer.tsx
@@ -119,7 +119,7 @@ export const Footer: React.FC = () => {
 
           {/* About */}
           <Box className="flex flex-col items-center md:items-start animate-in fade-in slide-in-from-bottom-4 duration-500 delay-100">
-            <Text variant="body" weight="semibold" gradient="blue">
+            <Text variant="body" weight="semibold" className="text-[#4285F4]">
               About
             </Text>
             <Stack gap="xs" className="items-center md:items-start">
@@ -139,7 +139,7 @@ export const Footer: React.FC = () => {
 
           {/* Network */}
           <Box className="flex flex-col items-center md:items-start animate-in fade-in slide-in-from-bottom-4 duration-500 delay-200">
-            <Text variant="body" weight="semibold" gradient="yellow">
+            <Text variant="body" weight="semibold" className="text-[#F9AB00]">
               Network
             </Text>
             <Stack gap="xs" className="items-center md:items-start">
@@ -159,7 +159,7 @@ export const Footer: React.FC = () => {
 
           {/* Nexus */}
           <Box className="flex flex-col items-center md:items-start animate-in fade-in slide-in-from-bottom-4 duration-500 delay-300">
-            <Text variant="body" weight="semibold" gradient="green">
+            <Text variant="body" weight="semibold" className="text-[#34A853]">
               Nexus
             </Text>
             <Stack gap="xs" className="items-center md:items-start">
@@ -179,7 +179,7 @@ export const Footer: React.FC = () => {
 
           {/* Address */}
           <Box className="flex flex-col items-center md:items-start animate-in fade-in slide-in-from-bottom-4 duration-500 delay-400">
-            <Text variant="body" weight="semibold" gradient="red">
+            <Text variant="body" weight="semibold" className="text-[#EA4335]">
               Address
             </Text>
             <Text variant="body-sm" className="text-gray-300 mb-4 text-center md:text-left">
@@ -200,7 +200,7 @@ export const Footer: React.FC = () => {
 
           {/* Contact */}
           <Box className="flex flex-col items-center md:items-start animate-in fade-in slide-in-from-bottom-4 duration-500 delay-500">
-            <Text variant="body" weight="semibold" gradient="red">
+            <Text variant="body" weight="semibold" className="text-[#4285F4]">
               Contact
             </Text>
             <Stack gap="xs" className="items-center md:items-start text-center md:text-left">


### PR DESCRIPTION
This pull request updates the color styling of section headers in the `Footer` component by replacing the use of gradient text with explicit hex color values. This change ensures consistent and precise coloring across different browsers and devices.

**Styling updates:**

* Replaced the `gradient` prop with explicit hex color classes for all section headers (`About`, `Network`, `Nexus`, `Address`, and `Contact`) in the `Footer` component within `Footer.tsx`. [[1]](diffhunk://#diff-46b2720d6ef3c861607754a709598e86c56deabcbb754490e60a4b4b7f0418ccL122-R122) [[2]](diffhunk://#diff-46b2720d6ef3c861607754a709598e86c56deabcbb754490e60a4b4b7f0418ccL142-R142) [[3]](diffhunk://#diff-46b2720d6ef3c861607754a709598e86c56deabcbb754490e60a4b4b7f0418ccL162-R162) [[4]](diffhunk://#diff-46b2720d6ef3c861607754a709598e86c56deabcbb754490e60a4b4b7f0418ccL182-R182) [[5]](diffhunk://#diff-46b2720d6ef3c861607754a709598e86c56deabcbb754490e60a4b4b7f0418ccL203-R203)