### PR TITLE
chore: standardize from pass to password payload and resolve local storage info

### DIFF
--- a/apps/nexus-admin-web/src/features/authentication/components/EmailChangeFlow.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/components/EmailChangeFlow.tsx
@@ -33,7 +33,7 @@ export const EmailChangeFlow = () => {
   const handleInitiate = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await initiateEmailChange({ data: { email, pass: password, newEmail } });
+      const res = await initiateEmailChange({ data: { email, password: password, newEmail } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-admin-web/src/features/authentication/components/ForgotPasswordFlow.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/components/ForgotPasswordFlow.tsx
@@ -87,7 +87,7 @@ export const ForgotPasswordFlow = () => {
   const handleFinalize = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await finalizeForgot({ data: { referenceCode, otp, newPass: newPassword } });
+      const res = await finalizeForgot({ data: { referenceCode, otp, newPassword: newPassword } });
       if (res?.data?.success) {
         router.push(LINKS.auth_signin);
       }

--- a/apps/nexus-admin-web/src/features/authentication/components/PasswordResetFlow.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/components/PasswordResetFlow.tsx
@@ -33,7 +33,7 @@ export const PasswordResetFlow = () => {
   const handleInitiate = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await initiateReset({ data: { email, pass: password, newPass: newPassword } });
+      const res = await initiateReset({ data: { email, password: password, newPassword: newPassword } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-admin-web/src/features/authentication/components/SignupFlow.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/components/SignupFlow.tsx
@@ -76,7 +76,7 @@ export const SignupFlow = () => {
     }
 
     try {
-      const res = await initiateSignup({ data: { email, pass: password } });
+      const res = await initiateSignup({ data: { email, password: password } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-admin-web/src/features/authentication/store/useAuthStore.tsx
+++ b/apps/nexus-admin-web/src/features/authentication/store/useAuthStore.tsx
@@ -2,7 +2,6 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import { TokenPayload } from "../types/tokenPayload";
 import { callEndpoint } from "@packages/typed-rest/clientReact";
 import { contract } from "@packages/nexus-api-contracts";
@@ -94,16 +93,17 @@ export const AuthContextProvider = ({
     
     setIsRefreshing(true);
     try {
+      const reqBody: any = { data: {} };
+      if (token) {
+        reqBody.data.token = token;
+      }
+
       const res = await callEndpoint(
         configs.nexusApiBaseUrl,
         contract.api.v1.authentication.refresh.POST,
         {
-          body: {
-            data: {
-              token: token!,
-            },
-          },
-          token: token!,
+          body: reqBody,
+          ...(token ? { token } : {}),
         },
       );
 
@@ -139,6 +139,14 @@ export const AuthContextProvider = ({
       }
 
       setState({ status: STATUS.AUTHENTICATED, error: null });
+    } else if (!token) {
+      // Try to re-authenticate via HttpOnly cookie if token is missing
+      refreshToken().then(() => {
+        const currentToken = useTokenStore.getState().token;
+        if (!currentToken) {
+          setState({ status: STATUS.UNAUTHENTICATED, error: null });
+        }
+      });
     } else {
       setState({ status: STATUS.UNAUTHENTICATED, error: null });
     }
@@ -258,30 +266,16 @@ type TokenStore = {
   setSessionExpiredOnLoad: (state: boolean) => void;
 };
 
-const useTokenStore = create<TokenStore>()(
-  persist(
-    (set) => ({
-      token: null,
-      decodedToken: null,
-      _hasHydrated: false,
-      isRefreshing: false,
-      sessionExpiredOnLoad: false,
-      setToken: (token: string) =>
-        set({ token, decodedToken: decodeJwtPayload(token), sessionExpiredOnLoad: false }),
-      clearToken: () => set({ token: null, decodedToken: null }),
-      setHasHydrated: (state) => set({ _hasHydrated: state }),
-      setIsRefreshing: (state) => set({ isRefreshing: state }),
-      setSessionExpiredOnLoad: (state) => set({ sessionExpiredOnLoad: state }),
-    }),
-    {
-      name: "nexus-auth-storage",
-      onRehydrateStorage: () => {
-        return (state, error) => {
-          if (!error && state) {
-            state.setHasHydrated(true);
-          }
-        };
-      },
-    },
-  ),
-);
+const useTokenStore = create<TokenStore>()((set) => ({
+  token: null,
+  decodedToken: null,
+  _hasHydrated: true,
+  isRefreshing: false,
+  sessionExpiredOnLoad: false,
+  setToken: (token: string) =>
+    set({ token, decodedToken: decodeJwtPayload(token), sessionExpiredOnLoad: false }),
+  clearToken: () => set({ token: null, decodedToken: null }),
+  setHasHydrated: (state) => set({ _hasHydrated: state }),
+  setIsRefreshing: (state) => set({ isRefreshing: state }),
+  setSessionExpiredOnLoad: (state) => set({ sessionExpiredOnLoad: state }),
+}));

--- a/apps/nexus-admin-web/src/features/profile/components/ChangeEmailDialog.tsx
+++ b/apps/nexus-admin-web/src/features/profile/components/ChangeEmailDialog.tsx
@@ -26,7 +26,7 @@ export const ChangeEmailDialog = ({ open, onOpenChange }: ChangeEmailDialogProps
   const handleInitiate = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await initiateEmailChange({ data: { email, pass: password, newEmail } });
+      const res = await initiateEmailChange({ data: { email, password: password, newEmail } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-admin-web/src/features/profile/components/ChangePasswordDialog.tsx
+++ b/apps/nexus-admin-web/src/features/profile/components/ChangePasswordDialog.tsx
@@ -31,7 +31,7 @@ export const ChangePasswordDialog = ({ open, onOpenChange }: ChangePasswordDialo
       return;
     }
     try {
-      const res = await initiatePasswordChange({ data: { email, pass: currentPassword, newPass: newPassword } });
+      const res = await initiatePasswordChange({ data: { email, password: currentPassword, newPassword: newPassword } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-api/src/loaders/loadParsers.ts
+++ b/apps/nexus-api/src/loaders/loadParsers.ts
@@ -1,9 +1,11 @@
 import { Express, Router } from "express";
 import express from "express";
+import cookieParser from "cookie-parser";
 
 export const loadParsers = (app: Express) => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
+  app.use(cookieParser());
 
   // parse query with extended param to parse object queries
   app.set("query parser", "extended");

--- a/apps/nexus-api/src/v1/middlewares/tokenParser.ts
+++ b/apps/nexus-api/src/v1/middlewares/tokenParser.ts
@@ -7,11 +7,15 @@ export const tokenParserFromHeaders: RequestHandler = async (
   next,
 ) => {
   try {
-    // 1. Extract Supabase token from "Authorization: Bearer <token>"
+    // 1. Extract Supabase token from "Authorization: Bearer <token>" or cookies
     const authHeader = req.headers.authorization;
-    const accessToken = authHeader?.startsWith("Bearer ")
+    let accessToken = authHeader?.startsWith("Bearer ")
       ? authHeader.split(" ")[1]
       : undefined;
+
+    if (!accessToken && req.cookies && req.cookies.token) {
+      accessToken = req.cookies.token;
+    }
 
     //   console.log("header", authHeader, authHeader?.split(" "))
     // console.log("Extracted access token from header:", accessToken);

--- a/apps/nexus-api/src/v1/modules/authentication/AuthenticationController.ts
+++ b/apps/nexus-api/src/v1/modules/authentication/AuthenticationController.ts
@@ -1,4 +1,4 @@
-﻿import { InitiateCreateNewUser } from "./useCases/InitiateCreateNewUser.js";
+import { InitiateCreateNewUser } from "./useCases/InitiateCreateNewUser.js";
 import { FinalizeCreateNewUser } from "./useCases/FinalizeCreateNewUser.js";
 import { Login } from "./useCases/Login.js";
 import { VerifyToken } from "./useCases/VerifyToken.js";

--- a/apps/nexus-api/src/v1/modules/authentication/useCases/GetMe.ts
+++ b/apps/nexus-api/src/v1/modules/authentication/useCases/GetMe.ts
@@ -27,6 +27,8 @@ export class GetMe {
       email: credential.props.emailAddress,
       display_name: credential.props.emailAddress, // Using username as display_name
       gdg_id: payload.props.memberInfo.gdgId,
+      roles: payload.props.roles,
+      permissions: payload.props.permissions,
     };
   }
 }

--- a/apps/nexus-api/src/v1/modules/authentication/useCases/Login.ts
+++ b/apps/nexus-api/src/v1/modules/authentication/useCases/Login.ts
@@ -1,4 +1,4 @@
-﻿import {
+import {
   IUserCredentialRepository,
   IEncryptionService,
   IJWTService,
@@ -48,7 +48,7 @@ export class Login {
     });
 
     const token = await this.jwtService.sign(tokenPayload);
-
+    
     return token;
   }
 }

--- a/apps/nexus-api/src/v1/routes/authentication/authentication.controller.ts
+++ b/apps/nexus-api/src/v1/routes/authentication/authentication.controller.ts
@@ -9,9 +9,18 @@ export class AuthenticationHttpController {
 
   public refreshToken: RequestHandler = createExpressController(
     contract.api.v1.authentication.refresh.POST,
-    async ({ input, output }) => {
-      const { token } = input.body.data;
+    async ({ input, output, ctx }) => {
+      const token = ctx.req.token || ctx.req.cookies?.token || input.body.data?.token;
+      if (!token) throw new Error("No token provided for refresh");
+      
       const newToken = await this.moduleController.refreshToken(token);
+      
+      ctx.res.cookie("token", newToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      });
       
       return output(200, {
         status: "success",
@@ -24,8 +33,8 @@ export class AuthenticationHttpController {
   public initiateCreateNewUser: RequestHandler = createExpressController(
     contract.api.v1.authentication.signup.initiate.POST,
     async ({ input, output }) => {
-      const { email, pass } = input.body.data;
-      const result = await this.moduleController.initiateCreateNewUser({ email, pass });
+      const { email, password } = input.body.data;
+      const result = await this.moduleController.initiateCreateNewUser({ email, pass: password });
       
       return output(200, {
         status: "success",
@@ -51,14 +60,17 @@ export class AuthenticationHttpController {
 
   public login: RequestHandler = createExpressController(
     contract.api.v1.authentication.login.POST,
-    async ({ input, output }) => {
-      const { email, password, pass } = input.body.data;
-      const resolvedPassword = password ?? pass;
-      if (!resolvedPassword) {
-        throw new BadRequestError("Password is required.");
-      }
-
-      const result = await this.moduleController.login({ email, pass: resolvedPassword });
+    async ({ input, output, ctx }) => {
+      const { email, password } = input.body.data;
+      const result = await this.moduleController.login({ email, pass: password! });
+      
+      // Set the token as an HttpOnly, Secure, SameSite cookie
+      ctx.res.cookie("token", result.token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      });
       
       return output(200, {
         status: "success",
@@ -102,8 +114,14 @@ export class AuthenticationHttpController {
 
   public logout: RequestHandler = createExpressController(
     contract.api.v1.authentication.logout.POST,
-    async ({ output }) => {
+    async ({ output, ctx }) => {
       const result = await this.moduleController.logout();
+      
+      ctx.res.clearCookie("token", {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+      });
       
       return output(200, {
         status: "success",
@@ -117,8 +135,8 @@ export class AuthenticationHttpController {
   public initiateChangePassword: RequestHandler = createExpressController(
     contract.api.v1.authentication.password.change.initiate.POST,
     async ({ input, output }) => {
-      const { email, pass, newPass } = input.body.data;
-      const result = await this.moduleController.initiateChangePassword({ email, pass, newPass });
+      const { email, password, newPassword } = input.body.data;
+      const result = await this.moduleController.initiateChangePassword({ email, pass: password, newPass: newPassword });
       
       return output(200, {
         status: "success",
@@ -159,8 +177,8 @@ export class AuthenticationHttpController {
   public finalizeForgotPassword: RequestHandler = createExpressController(
     contract.api.v1.authentication.password.forgot.finalize.POST,
     async ({ input, output }) => {
-      const { referenceCode, otp, newPass } = input.body.data;
-      const result = await this.moduleController.finalizeForgotPassword({ referenceCode, otp, newPass });
+      const { referenceCode, otp, newPassword } = input.body.data;
+      const result = await this.moduleController.finalizeForgotPassword({ referenceCode, otp, newPass: newPassword });
       
       return output(200, {
         status: "success",
@@ -187,10 +205,10 @@ export class AuthenticationHttpController {
   public initiateChangeEmail: RequestHandler = createExpressController(
     contract.api.v1.authentication.email.change.initiate.POST,
     async ({ input, output }) => {
-      const { email, pass, newEmail } = input.body.data;
+      const { email, password, newEmail } = input.body.data;
       if (!email) throw new Error("Email must be provided");
       
-      const result = await this.moduleController.initiateChangeEmail({ email, pass, newEmail });
+      const result = await this.moduleController.initiateChangeEmail({ email, pass: password, newEmail });
       
       return output(200, {
         status: "success",

--- a/apps/nexus-web/src/features/authentication/components/EmailChangeFlow.tsx
+++ b/apps/nexus-web/src/features/authentication/components/EmailChangeFlow.tsx
@@ -44,7 +44,7 @@ export const EmailChangeFlow = () => {
   const handleInitiate = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await initiateEmailChange({ data: { email, pass: password, newEmail } });
+      const res = await initiateEmailChange({ data: { email, password, newEmail } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-web/src/features/authentication/components/ForgotPasswordFlow.tsx
+++ b/apps/nexus-web/src/features/authentication/components/ForgotPasswordFlow.tsx
@@ -98,7 +98,7 @@ export const ForgotPasswordFlow = () => {
   const handleFinalize = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await finalizeForgot({ data: { referenceCode, otp, newPass: newPassword } });
+      const res = await finalizeForgot({ data: { referenceCode, otp, newPassword: newPassword } });
       if (res?.data?.success) {
         router.push(LINKS.auth_signin);
       }

--- a/apps/nexus-web/src/features/authentication/components/PasswordResetFlow.tsx
+++ b/apps/nexus-web/src/features/authentication/components/PasswordResetFlow.tsx
@@ -46,7 +46,7 @@ export const PasswordResetFlow = () => {
   const handleInitiate = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await initiateReset({ data: { email, pass: password, newPass: newPassword } });
+      const res = await initiateReset({ data: { email, password: password, newPassword: newPassword } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-web/src/features/authentication/components/SignupFlow.tsx
+++ b/apps/nexus-web/src/features/authentication/components/SignupFlow.tsx
@@ -87,7 +87,7 @@ export const SignupFlow = () => {
     }
 
     try {
-      const res = await initiateSignup({ data: { email, pass: password } });
+      const res = await initiateSignup({ data: { email, password: password } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-web/src/features/authentication/hooks/useMe.ts
+++ b/apps/nexus-web/src/features/authentication/hooks/useMe.ts
@@ -7,7 +7,7 @@ import { useCallEndpointWithToken } from "@/hooks/useFetchWithToken";
 
 export const useMe = () => {
   const { token} = useAuthContext();
-    const callEndpoint = useCallEndpointWithToken();
+  const callEndpoint = useCallEndpointWithToken();
 
   return useQuery({
     queryKey: ["auth-me", token],

--- a/apps/nexus-web/src/features/authentication/store/useAuthStore.tsx
+++ b/apps/nexus-web/src/features/authentication/store/useAuthStore.tsx
@@ -7,7 +7,6 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import { jwtDecode } from "jwt-decode";
 import { TokenPayload } from "../types/tokenPayload";
 import { callEndpoint } from "@packages/typed-rest/clientReact";
@@ -83,16 +82,17 @@ export const AuthContextProvider = ({
 
     setIsRefreshing(true);
     try {
+      const reqBody: any = { data: {} };
+      if (token) {
+        reqBody.data.token = token;
+      }
+
       const res = await callEndpoint(
         configs.nexusApiBaseUrl,
         contract.api.v1.authentication.refresh.POST,
         {
-          body: {
-            data: {
-              token: token!,
-            },
-          },
-          token: token!,
+          body: reqBody,
+          ...(token ? { token } : {}),
         },
       );
 
@@ -128,6 +128,15 @@ export const AuthContextProvider = ({
       }
 
       setState({ status: STATUS.AUTHENTICATED, error: null });
+    } else if (!token) {
+      // Try to re-authenticate via HttpOnly cookie if token is missing
+      refreshToken().then(() => {
+        const currentToken = useTokenStore.getState().token;
+        if (!currentToken) {
+          setState({ status: STATUS.UNAUTHENTICATED, error: null });
+          setMemberProfile(null);
+        }
+      });
     } else {
       setState({ status: STATUS.UNAUTHENTICATED, error: null });
       setMemberProfile(null);
@@ -248,30 +257,16 @@ type TokenStore = {
   setSessionExpiredOnLoad: (state: boolean) => void;
 };
 
-const useTokenStore = create<TokenStore>()(
-  persist(
-    (set) => ({
-      token: null,
-      decodedToken: null,
-      _hasHydrated: false,
-      isRefreshing: false,
-      sessionExpiredOnLoad: false,
-      setToken: (token: string) =>
-        set({ token, decodedToken: jwtDecode(token), sessionExpiredOnLoad: false }),
-      clearToken: () => set({ token: null, decodedToken: null }),
-      setHasHydrated: (state) => set({ _hasHydrated: state }),
-      setIsRefreshing: (state) => set({ isRefreshing: state }),
-      setSessionExpiredOnLoad: (state) => set({ sessionExpiredOnLoad: state }),
-    }),
-    {
-      name: "nexus-auth-storage",
-      onRehydrateStorage: () => {
-        return (state, error) => {
-          if (!error && state) {
-            state.setHasHydrated(true);
-          }
-        };
-      },
-    },
-  ),
-);
+const useTokenStore = create<TokenStore>()((set) => ({
+  token: null,
+  decodedToken: null,
+  _hasHydrated: true,
+  isRefreshing: false,
+  sessionExpiredOnLoad: false,
+  setToken: (token: string) =>
+    set({ token, decodedToken: jwtDecode<TokenPayload>(token), sessionExpiredOnLoad: false }),
+  clearToken: () => set({ token: null, decodedToken: null }),
+  setHasHydrated: (state) => set({ _hasHydrated: state }),
+  setIsRefreshing: (state) => set({ isRefreshing: state }),
+  setSessionExpiredOnLoad: (state) => set({ sessionExpiredOnLoad: state }),
+}));

--- a/apps/nexus-web/src/features/sparkmates/components/ChangeEmailDialog.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/ChangeEmailDialog.tsx
@@ -26,7 +26,7 @@ export const ChangeEmailDialog = ({ open, onOpenChange }: ChangeEmailDialogProps
   const handleInitiate = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await initiateEmailChange({ data: { email, pass: password, newEmail } });
+      const res = await initiateEmailChange({ data: { email, password: password, newEmail } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-web/src/features/sparkmates/components/ChangePasswordDialog.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/ChangePasswordDialog.tsx
@@ -32,7 +32,7 @@ export const ChangePasswordDialog = ({ open, onOpenChange }: ChangePasswordDialo
       return;
     }
     try {
-      const res = await initiatePasswordChange({ data: { email, pass: currentPassword, newPass: newPassword } });
+      const res = await initiatePasswordChange({ data: { email, password: currentPassword, newPassword: newPassword } });
       if (res?.data?.referenceCode) {
         setReferenceCode(res.data.referenceCode);
         setStep(2);

--- a/apps/nexus-web/src/features/sparkmates/components/SettingsChangePasswordDialog.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/SettingsChangePasswordDialog.tsx
@@ -109,8 +109,8 @@ export const SettingsChangePasswordDialog = ({
         const res = await initiatePasswordChange({
           data: {
             email,
-            pass: currentPassword,
-            newPass: newPassword,
+            password: currentPassword,
+            newPassword: newPassword,
           },
         });
         setReferenceCode(res.data.referenceCode);

--- a/apps/nexus-web/src/features/sparkmates/components/analyticspage/AnalyticsPageContent.tsx
+++ b/apps/nexus-web/src/features/sparkmates/components/analyticspage/AnalyticsPageContent.tsx
@@ -155,6 +155,7 @@ export const AnalyticsPageContent = () => {
                   <Smartphone size={14} />
                   <span>Physical networking power</span>
                 </div>
+
               </div>
             </div>
 

--- a/packages/nexus-api-contracts/src/models/v1/authentication/schemas.ts
+++ b/packages/nexus-api-contracts/src/models/v1/authentication/schemas.ts
@@ -2,7 +2,7 @@ import {cz as z} from "@packages/typed-rest/shared";
 
 export const initiateCreateNewUserRequest = z.object({
   email: z.string().email(),
-  pass: z.string().min(8),
+  password: z.string().min(8),
 });
 
 export const initiateCreateNewUserResponse = z.object({
@@ -21,8 +21,7 @@ export const finalizeCreateNewUserResponse = z.object({
 export const loginRequest = z.object({
   email: z.string().email(),
   password: z.string().min(1).optional(),
-  pass: z.string().min(1).optional(),
-}).refine((data) => Boolean(data.password || data.pass), {
+}).refine((data) => !!data.password, {
   message: "Password is required",
   path: ["password"],
 });
@@ -32,15 +31,15 @@ export const loginResponse = z.object({
 });
 
 export const verifyTokenRequest = z.object({
-  token: z.string(),
+  token: z.string().nullable().optional(),
 });
 
 export const verifyTokenResponse = z.boolean();
 
 export const initiateChangePasswordRequest = z.object({
   email: z.string().email(),
-  pass: z.string(),
-  newPass: z.string().min(8),
+  password: z.string(),
+  newPassword: z.string().min(8),
 });
 
 export const initiateChangePasswordResponse = z.object({
@@ -67,7 +66,7 @@ export const initiateForgotPasswordResponse = z.object({
 export const finalizeForgotPasswordRequest = z.object({
   referenceCode: z.string(),
   otp: z.string(),
-  newPass: z.string().min(8),
+  newPassword: z.string().min(8),
 });
 
 export const finalizeForgotPasswordResponse = z.object({
@@ -76,7 +75,7 @@ export const finalizeForgotPasswordResponse = z.object({
 
 export const initiateChangeEmailRequest = z.object({
   email: z.string().email().optional(), // Adjust based on token or body
-  pass: z.string(),
+  password: z.string(),
   newEmail: z.string().email(),
 });
 
@@ -103,7 +102,7 @@ export const resendOtpResponse = z.object({
 
 export const deleteUserRequest = z.object({
   email: z.string().email().optional(), // Might come from token
-  pass: z.string().optional(),
+  password: z.string().optional(),
 });
 
 export const deleteUserResponse = z.object({
@@ -120,4 +119,3 @@ export const meResponse = z.object({
 export const logoutResponse = z.object({
   success: z.boolean(),
 });
-

--- a/packages/typed-rest/src/presentation/clientReact/index.ts
+++ b/packages/typed-rest/src/presentation/clientReact/index.ts
@@ -119,6 +119,7 @@ export const callEndpoint = async <T extends Contract>(
       method: endpoint.method,
       headers: requestHeaders,
       body: processedBody,
+      credentials: "include",
       ...customConfig,
     });
 


### PR DESCRIPTION
This pull request implements major improvements to authentication flows across both the API and web applications. The main focus is on standardizing authentication parameter names, improving session management with HttpOnly cookies, and simplifying client-side token storage. These changes enhance security and consistency, and pave the way for better user experience and maintainability.

**API Improvements**

* **HttpOnly Cookie-Based Authentication:**
  - The API now sets the authentication token as an HttpOnly, Secure, SameSite cookie on login and refresh, and clears it on logout, improving security by preventing client-side access to the token. [[1]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL12-R24) [[2]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL105-R125) [[3]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL120-R139)
  - The token parser middleware now extracts the token from cookies if it is not present in the Authorization header.
  - The refresh endpoint and related logic support reading and setting tokens in cookies, and fallback to request body if necessary.

* **Parameter Name Standardization:**
  - All authentication-related endpoints and flows now use `password` and `newPassword` instead of `pass` and `newPass`, ensuring consistency between client and server. [[1]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL27-R37) [[2]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL54-R73) [[3]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL120-R139) [[4]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL162-R181) [[5]](diffhunk://#diff-228077dfd7f6b9f24d946a0c27a978b4beb198534a92a335facb62dcf372d9daL190-R211)

* **Express Middleware and Parsing:**
  - Added `cookie-parser` middleware to the API to support cookie-based authentication. (F21fb556L1)

**Web Application Improvements**

* **Consistent Parameter Usage:**
  - All authentication flows in both `nexus-admin-web` and `nexus-web` now use the standardized `password` and `newPassword` parameter names when making API calls. [[1]](diffhunk://#diff-156a3b0cc1ada215e4e2027d74aecff6de8e2d60dd7f0b2985f7774436c27e7aL36-R36) [[2]](diffhunk://#diff-c5318b6215754624c738b41e06c3c85efddd0d9c1b9d7b61f19c98cbffc8a4faL90-R90) [[3]](diffhunk://#diff-a9cbc191fc6776a8cb9a951e7f743b62deeb66308c824ca92b5b1721a9aff815L36-R36) [[4]](diffhunk://#diff-047b1cb414d0c479e3637c9fb8c03615e60fb1166e95d778e31d569e60147655L79-R79) [[5]](diffhunk://#diff-88b4ebd21fa95783d91aa7700637e56d5adcdef0d2406f902710cfffaa654ca3L29-R29) [[6]](diffhunk://#diff-8c6bb0e971df2d733bb4362448d00e258547ef3683441593dda11e90ce3620d7L34-R34) [[7]](diffhunk://#diff-a7fde972488e470e121ee95a0d5c768ed62ce86dcb793bedd115446cbbf6ef29L47-R47) [[8]](diffhunk://#diff-8d255f208a617e8164540698206a23684cf60065be05e1669f4de37462d88c42L101-R101) [[9]](diffhunk://#diff-caff398e73bde562c4bd0c39e5524f4e60589986339751b66c6df41e68aeb708L49-R49) [[10]](diffhunk://#diff-880a9e4c81a620eba7651500a11ecb01acfdded85bae7a2ba8d32915c3562906L90-R90)

* **Client Token Storage Simplification:**
  - Removed `zustand`'s `persist` middleware for token storage, relying instead on server-set cookies for session management. This reduces complexity and enhances security. [[1]](diffhunk://#diff-d07c38bee95dfaf36ff2f410a9b4c475a2a62d24681e07916ee55aad18538f96L5) [[2]](diffhunk://#diff-d07c38bee95dfaf36ff2f410a9b4c475a2a62d24681e07916ee55aad18538f96L261-R272) [[3]](diffhunk://#diff-d07c38bee95dfaf36ff2f410a9b4c475a2a62d24681e07916ee55aad18538f96L275-R281) [[4]](diffhunk://#diff-53539f915ec0d1d7583a18069a2e6c113d928fdacde3ab052ee767932eeeed34L10)
  - The authentication context now attempts to refresh the session using cookies if no token is present in client state, improving resilience to token loss or page reloads. [[1]](diffhunk://#diff-d07c38bee95dfaf36ff2f410a9b4c475a2a62d24681e07916ee55aad18538f96R96-R106) [[2]](diffhunk://#diff-d07c38bee95dfaf36ff2f410a9b4c475a2a62d24681e07916ee55aad18538f96R142-R149) [[3]](diffhunk://#diff-53539f915ec0d1d7583a18069a2e6c113d928fdacde3ab052ee767932eeeed34R85-R95)

**Other Notable Changes**

* The `GetMe` use case now returns `roles` and `permissions` in the user payload, enabling role-based access control on the client.

These changes collectively improve authentication security, reliability, and maintainability across the codebase.