### PR TITLE
chore: resolve the loading issues for the events

### DIFF
--- a/apps/nexus-web/src/features/events/components/GalleryYearSection.tsx
+++ b/apps/nexus-web/src/features/events/components/GalleryYearSection.tsx
@@ -85,6 +85,7 @@ export function GalleryYearSection({ yearParam }: GalleryYearSectionProps) {
     data: events,
     error: errorMessage,
     isLoading,
+    isFetching,
   } = useEvents({ year: parsedYear, pageSize });
 
   const visibleItems = useMemo(() => {

--- a/apps/nexus-web/src/features/events/hooks/useEvents.ts
+++ b/apps/nexus-web/src/features/events/hooks/useEvents.ts
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, useMemo } from "react";
 import { EventsQueryParams, EventFilters, Event } from "../types";
 import { useCallEndpointWithToken } from "@/hooks/useFetchWithToken";
@@ -65,6 +65,7 @@ export function useEvents(params: EventsQueryParams = {}) {
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes (renamed from cacheTime)
     retry: 2,
+    placeholderData: keepPreviousData,
   });
 }
 


### PR DESCRIPTION
Closes #1238

This pull request improves the event fetching experience in the events feature by ensuring smoother UI updates and more consistent data handling during pagination or filter changes. The main changes involve leveraging React Query's `keepPreviousData` to prevent UI flicker and exposing the `isFetching` state for better loading feedback.

**Event data fetching improvements:**

* `useEvents` hook now uses `placeholderData: keepPreviousData` to retain previous event data while fetching new data, reducing UI flicker during pagination or filtering.
* The `isFetching` state from React Query is now exposed in the `GalleryYearSection` component, allowing for more granular loading indicators beyond the initial load.

**Dependency update:**

* Imported `keepPreviousData` from `@tanstack/react-query` in the `useEvents` hook to support the above functionality.