### PR TITLE
chore: use the actual aspect ratio from the bevy

### DIFF
--- a/apps/nexus-web/src/features/events/components/EventHighlightsGallerySection.tsx
+++ b/apps/nexus-web/src/features/events/components/EventHighlightsGallerySection.tsx
@@ -16,7 +16,7 @@ type EventHighlightsGallerySectionProps = {
 
 
 
-const PLACEHOLDER_TILE_URL = "/pages/events/event-cover.webp";
+const PLACEHOLDER_TILE_URL = "https://res.cloudinary.com/startup-grind/image/upload/c_scale,w_2560/c_crop,h_640,w_2560,y_0.0_mul_h_sub_0.0_mul_640/c_crop,h_640,w_2560/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-goog/event_banners/GDG_Bevy_DefaultEventBanner_VKOwYjb.png";
 const EVENT_MAX_IMAGES = 20;
 const PLACEHOLDER_IMAGES = Array.from(
   { length: EVENT_MAX_IMAGES },

--- a/apps/nexus-web/src/features/events/components/GalleryYearSection.tsx
+++ b/apps/nexus-web/src/features/events/components/GalleryYearSection.tsx
@@ -15,7 +15,7 @@ type GalleryYearSectionProps = {
   yearParam: string;
 };
 
-const FALLBACK_COVER = "/pages/events/event-cover.webp";
+const FALLBACK_COVER = "https://res.cloudinary.com/startup-grind/image/upload/c_scale,w_2560/c_crop,h_640,w_2560,y_0.0_mul_h_sub_0.0_mul_640/c_crop,h_640,w_2560/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-goog/event_banners/GDG_Bevy_DefaultEventBanner_VKOwYjb.png";
 
 function getHighlightsRouteId(event: Event): string {
   const candidate =
@@ -365,14 +365,14 @@ export function GalleryYearSection({ yearParam }: GalleryYearSectionProps) {
                   <article
                     key={`${event.id}-${event.start_date}-${event.title}`}
                   >
-                    <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-black min-h-[220px] md:min-h-[560px]">
+                    <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-black/50 w-full flex items-center justify-center">
                       <img
                         src={event.image_url || event.images?.[0] || FALLBACK_COVER}
                         alt={event.title}
-                        className="absolute inset-0 h-full w-full object-cover object-center"
+                        className="w-full h-auto max-h-[75vh] object-contain object-center block"
                         draggable={false}
                       />
-                      <div className="absolute inset-0 bg-linear-to-r from-black/45 via-black/10 to-transparent" />
+                      <div className="absolute inset-0 bg-linear-to-r from-black/45 via-black/10 to-transparent pointer-events-none" />
                     </div>
 
                     <div className="mt-5 md:mt-7">


### PR DESCRIPTION
This pull request updates the fallback and placeholder event banner images used in the events gallery components and improves the display of event images in the gallery. The main focus is on ensuring a consistent, high-quality default image and enhancing image presentation.

**Image source updates:**

* Updated the `PLACEHOLDER_TILE_URL` in `EventHighlightsGallerySection.tsx` and the `FALLBACK_COVER` in `GalleryYearSection.tsx` to use a high-quality, externally hosted default event banner image, replacing the previous local asset. [[1]](diffhunk://#diff-6ad360a2a8dfce5621bbe90327979c897b1ff8fe98098d391eb00ad1ebbe2f37L19-R19) [[2]](diffhunk://#diff-6fe445eb84584850b00ea2d53febf7d4584811417c9a3385de8a414bd04de0aaL18-R18)

**Gallery image display improvements:**

* Modified the event image container in `GalleryYearSection.tsx` to use a semi-transparent black background and center images with `object-contain`, ensuring better presentation for images of varying aspect ratios.
* Adjusted the overlay div to be non-interactive (`pointer-events-none`) to prevent it from blocking user interaction with underlying content.

<img width="555" height="815" alt="image" src="https://github.com/user-attachments/assets/1054e44c-6728-43e6-bd59-2689e9d8470e" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/59908852-bffc-4bc7-81e5-10a8740e17c0" />
