### PR TITLE
fix: solve the cannot signout bug

### DIFF
--- a/apps/nexus-web/src/features/authentication/store/useAuthStore.tsx
+++ b/apps/nexus-web/src/features/authentication/store/useAuthStore.tsx
@@ -202,6 +202,18 @@ export const AuthContextProvider = ({
   const logout = async () => {
     setState({ status: STATUS.LOGGINGOUT, error: null });
     try {
+      try {
+        await callEndpoint(
+          configs.nexusApiBaseUrl,
+          contract.api.v1.authentication.logout.POST,
+          {
+            ...(token ? { token } : {}),
+          } as any,
+        );
+      } catch (err) {
+        console.error("Backend logout failed:", err);
+      }
+
       clearToken();
       setState({ status: STATUS.UNAUTHENTICATED, error: null });
 


### PR DESCRIPTION
This pull request introduces an improvement to the logout flow in the authentication logic by handling potential backend failures more gracefully. The main change ensures that even if the backend logout request fails, the client will still clear the token and update the authentication state, thus preventing users from being stuck in an inconsistent state.

- **Authentication flow robustness:**
  * Updated the `logout` function in `useAuthStore.tsx` to wrap the backend logout API call in a try/catch block, logging any errors but proceeding to clear the token and update the authentication state regardless of backend response.